### PR TITLE
Avoid separate cache for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rust:
 if: type != push OR (tag IS blank AND branch = master)
 
 before_script:
- - if [[ "$INTEGRATION" == "true" ]]; then
+ - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Integration" || "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
      docker pull greenmail/standalone:1.5.8 &&
      docker run -d -e GREENMAIL_OPTS='-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose' -p 3025:3025 -p 3110:3110 -p 3143:3143 -p 3465:3465 -p 3993:3993 -p 3995:3995 greenmail/standalone:1.5.8;
    fi
@@ -50,7 +50,6 @@ jobs:
         apt:
           packages:
             - libssl-dev
-      env: INTEGRATION=true
       rust: stable
       os: linux
     - <<: *integration
@@ -85,7 +84,7 @@ jobs:
     - <<: *integration
       stage: coverage
       rust: nightly
-      env: CACHE_NAME=coverage INTEGRATION=true
+      env: CACHE_NAME=coverage
       script:
         - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin || true
         - cargo tarpaulin --out Xml
@@ -99,4 +98,4 @@ stages:
  - coverage
 
 after_failure:
- - if [[ "$INTEGRATION" == "true" ]]; then docker logs $(docker ps -q); fi
+ - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Integration" || "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then docker logs $(docker ps -q); fi


### PR DESCRIPTION
Travis uses [several factors](https://docs.travis-ci.com/user/caching/#caches-and-build-matrices) to determine whether a given job shares a cache with a different job. In particular, it uses any environment variables specified in `.travis.yml`. Previously, integration tests set `INTEGRATION=true`, which meant that the integration tests did not share a cache with the non-integration tests, even though the compilation is exactly the same.

This patch fixes that by remvoing the `INTEGRATION` environment variable and instead using the globally available [`$TRAVIS_BUILD_STAGE_NAME`](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) to run the setup required for integration tests only in stages that run integration tests (namely integration and coverage). Now, the test and integration stages share all the parameters that Travis uses to determine cache identifiers, and so they&#39;ll share their cache!

Coverage still uses its own cache because it specifically needs to *not* cache the compiled crate, but *does* need to cache `cargo-tarpaulin`.