### PR TITLE
Add Fetch.internal_date method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bufstream = "0.1"
 imap-proto = "0.7"
 nom = "4.0"
 base64 = "0.10"
+chrono = "0.4"
 
 [dev-dependencies]
 lettre = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,11 +62,11 @@
 
 extern crate base64;
 extern crate bufstream;
+extern crate chrono;
 extern crate imap_proto;
 extern crate native_tls;
 extern crate nom;
 extern crate regex;
-extern crate chrono;
 
 mod parse;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ extern crate imap_proto;
 extern crate native_tls;
 extern crate nom;
 extern crate regex;
+extern crate chrono;
 
 mod parse;
 

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -2,6 +2,9 @@ use super::{Flag, Seq, Uid};
 use imap_proto::types::{AttributeValue, Envelope, MessageSection, SectionPath};
 use chrono::{DateTime, FixedOffset};
 
+/// Format of Date and Time as defined RFC3501.
+/// See `date-time` element in [Formal Syntax](https://tools.ietf.org/html/rfc3501#section-9)
+/// chapter of this RFC.
 const DATE_TIME_FORMAT: &str = "%d-%b-%Y %H:%M:%S %z";
 
 /// An IMAP [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2) that contains
@@ -131,7 +134,7 @@ impl Fetch {
         self.fetch
             .iter()
             .filter_map(|av| match av {
-                AttributeValue::InternalDate(str) => Some(*str),
+                AttributeValue::InternalDate(date_time) => Some(*date_time),
                 _ => None,
             })
             .next()

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -1,6 +1,6 @@
 use super::{Flag, Seq, Uid};
-use imap_proto::types::{AttributeValue, Envelope, MessageSection, SectionPath};
 use chrono::{DateTime, FixedOffset};
+use imap_proto::types::{AttributeValue, Envelope, MessageSection, SectionPath};
 
 /// Format of Date and Time as defined RFC3501.
 /// See `date-time` element in [Formal Syntax](https://tools.ietf.org/html/rfc3501#section-9)
@@ -138,11 +138,11 @@ impl Fetch {
                 _ => None,
             })
             .next()
-            .and_then(|date_time|
-                match DateTime::parse_from_str(date_time, DATE_TIME_FORMAT) {
+            .and_then(
+                |date_time| match DateTime::parse_from_str(date_time, DATE_TIME_FORMAT) {
                     Ok(date_time) => Some(date_time),
                     Err(_) => None,
-                }
+                },
             )
     }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -119,4 +119,18 @@ impl Fetch {
             })
             .next()
     }
+    
+    /// Extract the `INTERNALDATE` of a `FETCH` response
+    ///
+    /// See [section 2.3.3 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-2.3.3) for
+    /// details.
+    pub fn internal_date(&self) -> Option<&str> {
+        self.fetch
+            .iter()
+            .filter_map(|av| match av {
+                AttributeValue::InternalDate(str) => Some(*str),
+                _ => None,
+            })
+            .next()
+    }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -1,5 +1,8 @@
 use super::{Flag, Seq, Uid};
 use imap_proto::types::{AttributeValue, Envelope, MessageSection, SectionPath};
+use chrono::{DateTime, FixedOffset};
+
+const DATE_TIME_FORMAT: &str = "%d-%b-%Y %H:%M:%S %z";
 
 /// An IMAP [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2) that contains
 /// data about a particular message. This response occurs as the result of a `FETCH` or `STORE`
@@ -124,7 +127,7 @@ impl Fetch {
     ///
     /// See [section 2.3.3 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-2.3.3) for
     /// details.
-    pub fn internal_date(&self) -> Option<&str> {
+    pub fn internal_date(&self) -> Option<DateTime<FixedOffset>> {
         self.fetch
             .iter()
             .filter_map(|av| match av {
@@ -132,5 +135,11 @@ impl Fetch {
                 _ => None,
             })
             .next()
+            .and_then(|date_time|
+                match DateTime::parse_from_str(date_time, DATE_TIME_FORMAT) {
+                    Ok(date_time) => Some(date_time),
+                    Err(_) => None,
+                }
+            )
     }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -119,7 +119,7 @@ impl Fetch {
             })
             .next()
     }
-    
+
     /// Extract the `INTERNALDATE` of a `FETCH` response
     ///
     /// See [section 2.3.3 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-2.3.3) for

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -134,6 +134,8 @@ fn inbox() {
     let to = &e.to.as_ref().unwrap()[0];
     assert_eq!(to.mailbox, Some("inbox"));
     assert_eq!(to.host, Some("localhost"));
+    let date_opt = fetch.internal_date();
+    assert!(date_opt.is_some());
 
     // and let's delete it to clean up
     c.store("1", "+FLAGS (\\Deleted)").unwrap();
@@ -190,6 +192,8 @@ fn inbox_uid() {
     assert_eq!(fetch.uid, Some(uid));
     let e = fetch.envelope().unwrap();
     assert_eq!(e.subject, Some("My first e-mail"));
+    let date_opt = fetch.internal_date();
+    assert!(date_opt.is_some());
 
     // and let's delete it to clean up
     c.uid_store(format!("{}", uid), "+FLAGS (\\Deleted)")


### PR DESCRIPTION
This method gives the internal date from the FETCH answer.

Fixes #112 