### PR TITLE
Implemented iteration over unsolicited responses during IDLE.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ imap-proto = "0.7"
 nom = "4.0"
 base64 = "0.10"
 fallible-iterator = "0.2.0"
+enumset = "0.3.18"
 
 [dev-dependencies]
 lettre = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bufstream = "0.1"
 imap-proto = "0.7"
 nom = "4.0"
 base64 = "0.10"
+fallible-iterator = "0.2.0"
 
 [dev-dependencies]
 lettre = "0.9"

--- a/src/client.rs
+++ b/src/client.rs
@@ -995,7 +995,8 @@ impl<T: Read + Write> Session<T> {
     ///
     /// See [`extensions::idle::Handle`] for details.
     pub fn idle(&mut self) -> Result<extensions::idle::Handle<T>> {
-        extensions::idle::Handle::make(self)
+        let sender = self.unsolicited_responses_tx.clone();
+        extensions::idle::Handle::make(self, sender)
     }
 
     /// The [`APPEND` command](https://tools.ietf.org/html/rfc3501#section-6.3.11) appends

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -43,9 +43,9 @@ pub struct Handle<'a, T: Read + Write + 'a> {
 
 
 /// 'IdleIterator' allows a client to iterate over unsolicited responses during an IDLE operation.
-/// Only the unsolicited responses requested by the [`Session::request`] method will be
-/// returned. If there are still unhandled responses in the `unsolicited_response` channel
-/// of the [`Session`], those will be iterated through first before waiting for new ones.
+/// Only the unsolicited responses requested by the [`Session::request_unsolicited_responses`]
+/// method will be returned. If there are still unhandled responses in the `unsolicited_response`
+/// channel of the [`Session`], those will be iterated through first before waiting for new ones.
 ///
 /// As long as a [`IdleIterator`] is active, the mailbox cannot be otherwise accessed.
 pub struct IdleIterator<'a, T: Read + Write + 'a> {
@@ -166,9 +166,10 @@ impl<'a, T: SetReadTimeout + Read + Write + 'a> Handle<'a, T> {
 
     /// Returns an iterator over unsolicited responses.
     ///
-    /// Only the unsolicited responses requested by the [`Session::request`] method will be
-    /// returned. If there are still unhandled responses in the `unsolicited_response` channel
-    /// of the [`Session`], those will be iterated through first before waiting for new ones.
+    /// Only the unsolicited responses requested by the [`Session::request_unsolicited_responses`]
+    /// method will be returned. If there are still unhandled responses in the
+    /// `unsolicited_response` channel of the [`Session`], those will be iterated through first
+    /// before waiting for new ones.
     ///
     /// This method differs from [`Handle::iter`] in that it will periodically refresh the IDLE
     /// connection, to prevent the server from timing out our connection. The keepalive interval is

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -139,9 +139,10 @@ impl<'a, T: Read + Write + 'a> Handle<'a, T> {
 
     /// Returns an iterator over unsolicited responses.
     ///
-    /// Only the unsolicited responses requested by the [`Session::request`] method will be
-    /// returned. If there are still unhandled responses in the `unsolicited_response` channel
-    /// of the [`Session`], those will be iterated through first before waiting for new ones.
+    /// Only the unsolicited responses requested by the [`Session::request_unsolicited_responses`]
+    /// method will be returned. If there are still unhandled responses in the
+    /// `unsolicited_response` channel of the [`Session`], those will be iterated through first
+    /// before waiting for new ones.
     ///
     /// The iteration will stop if an error occurs.
     pub fn iter(self) -> IdleIterator<'a, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ extern crate imap_proto;
 extern crate native_tls;
 extern crate nom;
 extern crate regex;
+extern crate fallible_iterator;
 
 mod parse;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,11 @@ extern crate native_tls;
 extern crate nom;
 extern crate regex;
 extern crate fallible_iterator;
+#[macro_use]
+extern crate enumset;
 
 mod parse;
+mod unsolicited_responses;
 
 pub mod types;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -299,10 +299,10 @@ pub fn parse_ids(
     }
 }
 
-pub fn parse_idle(
-    mut lines: &[u8],
+pub fn parse_idle<'a>(
+    mut lines: &'a [u8],
     unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
-) -> Result<()> {
+) -> Result<&'a [u8]> {
     while !lines.is_empty() {
         match imap_proto::parse_response(lines) {
             Ok((rest, data)) => {
@@ -311,12 +311,13 @@ pub fn parse_idle(
                     return Err(resp.into());
                 }
             }
+            Err(nom::Err::Incomplete(_)) => break,
             Err(_) => {
                 return Err(Error::Parse(ParseError::Invalid(lines.to_vec())));
             }
         }
     }
-    Ok(())
+    Ok(lines)
 }
 
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -267,6 +267,8 @@ pub enum UnsolicitedFetchAttribute {
 #[derive(Debug, PartialEq, Eq)]
 pub enum UnsolicitedResponse {
     /// An unsolicited [`STATUS response`](https://tools.ietf.org/html/rfc3501#section-7.2.4).
+    ///
+    /// It can only happen during a [`Session::status`] command.
     Status {
         /// The mailbox that this status response is for.
         mailbox: String,
@@ -356,6 +358,35 @@ pub enum UnsolicitedResponse {
         attributes: Vec<UnsolicitedFetchAttribute>,
     },
 }
+
+
+enum_set_type! {
+    /// Unsolicited responses categories, to be used by the
+    /// [`Session::request_unsolicited_responses`] method.
+    pub enum UnsolicitedResponseCategory {
+        /// Asks for `RECENT` responses.
+        Recent,
+        /// Asks for `EXISTS` responses.
+        Exists,
+        /// Asks for `EXPUNGE` responses.
+        Expunge,
+        /// Asks for `OK` responses.
+        Ok,
+        /// Asks for `NO` responses.
+        No,
+        /// Asks for `BAD` responses.
+        Bad,
+        /// Asks for the `BYE` response.
+        Bye,
+        /// Asks for `STATUS` responses.
+        Status,
+        /// Asks for `FETCH` responses.
+        Fetch,
+    }
+}
+
+pub use enumset::EnumSet;
+
 
 /// This type wraps an input stream and a type that was constructed by parsing that input stream,
 /// which allows the parsed type to refer to data in the underlying stream instead of copying it.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -204,6 +204,60 @@ pub use self::capabilities::Capabilities;
 /// re-exported from imap_proto;
 pub use imap_proto::StatusAttribute;
 
+
+// We need a ResponseCode that is not tied to a lifetime, to be used in UnsolicitedResponse.
+/// Response code that may be sent with OK/NO/BAD/BYE responses.
+/// See [RFC 3501](https://tools.ietf.org/html/rfc3501#section-3.1).
+#[derive(Debug, Eq, PartialEq)]
+pub enum ResponseCode {
+    //Alert: not parsed by imap-proto yet.
+    //BadCharset: not parsed by imap-proto yet.
+    //Capability: not parsed by imap-proto yet.
+    //Parse: not parsed by imap-proto yet.
+    /// See [RFC 4551](https://tools.ietf.org/html/rfc4551#section-3.1.1).
+    HighestModSeq(u64),
+    /// Flags that can be changed permanently.
+    PermanentFlags(Vec<String>),
+    /// The mailbox status has changed to read-only.
+    ReadOnly,
+    /// The mailbox status has changed to read-write.
+    ReadWrite,
+    /// Indicates that the mailbox must be created first.
+    TryCreate,
+    /// Next unique identifier value.
+    UidNext(u32),
+    /// The unique identifier validity value.
+    UidValidity(u32),
+    /// First message without the \Seen flag set.
+    Unseen(u32),
+}
+
+impl<'a> From<imap_proto::types::ResponseCode<'a>> for ResponseCode {
+    fn from(r: imap_proto::types::ResponseCode<'a>) -> Self {
+        match r {
+            imap_proto::types::ResponseCode::HighestModSeq(n) => ResponseCode::HighestModSeq(n),
+            imap_proto::types::ResponseCode::PermanentFlags(v) =>
+                ResponseCode::PermanentFlags(v.iter().map(|x| (*x).into()).collect()),
+            imap_proto::types::ResponseCode::ReadOnly => ResponseCode::ReadOnly,
+            imap_proto::types::ResponseCode::ReadWrite => ResponseCode::ReadWrite,
+            imap_proto::types::ResponseCode::TryCreate => ResponseCode::TryCreate,
+            imap_proto::types::ResponseCode::UidNext(n) => ResponseCode::UidNext(n),
+            imap_proto::types::ResponseCode::UidValidity(n) => ResponseCode::UidValidity(n),
+            imap_proto::types::ResponseCode::Unseen(n) => ResponseCode::Unseen(n),
+        }
+    }
+}
+
+/// An attribute of the message refered to by a FETCH unsolicited response.
+#[derive(Debug, Eq, PartialEq)]
+pub enum UnsolicitedFetchAttribute {
+    /// The set of flags of this message.
+    Flags(Vec<String>),
+    /// Some other attribute not handled yet.
+    // I don't know which attributes besides FLAGS make sense to be sent unsolicited.
+    Other,
+}
+
 /// Responses that the server sends that are not related to the current command.
 /// [RFC 3501](https://tools.ietf.org/html/rfc3501#section-7) states that clients need to be able
 /// to accept any response at any time. These are the ones we've encountered in the wild.
@@ -260,8 +314,47 @@ pub enum UnsolicitedResponse {
     /// server will send five untagged `EXPUNGE` responses for message sequence number 5, whereas a
     /// "higher to lower server" will send successive untagged `EXPUNGE` responses for message
     /// sequence numbers 9, 8, 7, 6, and 5.
-    // TODO: the spec doesn't seem to say anything about when these may be received as unsolicited?
     Expunge(u32),
+
+    /// An unsolicited [`OK` response](https://tools.ietf.org/html/rfc3501#section-7.1.1).
+    Ok {
+        /// Optional response code.
+        code: Option<ResponseCode>,
+        /// Information text that may be presented to the user.
+        information: Option<String>,
+    },
+
+    /// An unsolicited [`NO` response](https://tools.ietf.org/html/rfc3501#section-7.1.2).
+    No {
+        /// Optional response code.
+        code: Option<ResponseCode>,
+        /// Information text that may be presented to the user.
+        information: Option<String>,
+    },
+
+    /// An unsolicited [`BAD` response](https://tools.ietf.org/html/rfc3501#section-7.1.3).
+    Bad {
+        /// Optional response code.
+        code: Option<ResponseCode>,
+        /// Information text that may be presented to the user.
+        information: Option<String>,
+    },
+
+    /// An unsolicited [`BYE` response](https://tools.ietf.org/html/rfc3501#section-7.1.5).
+    Bye {
+        /// Optional response code.
+        code: Option<ResponseCode>,
+        /// Information text that may be presented to the user.
+        information: Option<String>,
+    },
+
+    /// An unsolicited [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2).
+    Fetch {
+        /// Message identifier.
+        id: u32,
+        /// Attribute values for this message.
+        attributes: Vec<UnsolicitedFetchAttribute>,
+    },
 }
 
 /// This type wraps an input stream and a type that was constructed by parsing that input stream,

--- a/src/unsolicited_responses.rs
+++ b/src/unsolicited_responses.rs
@@ -1,0 +1,48 @@
+use enumset::EnumSet;
+use std::sync::mpsc;
+
+use super::types::{UnsolicitedResponse, UnsolicitedResponseCategory};
+
+#[derive(Debug, Clone)]
+pub struct UnsolicitedResponseSender {
+    sender: mpsc::Sender<UnsolicitedResponse>,
+    allow: EnumSet<UnsolicitedResponseCategory>,
+}
+
+
+impl UnsolicitedResponseSender {
+    pub fn new(sender: mpsc::Sender<UnsolicitedResponse>) -> UnsolicitedResponseSender {
+        UnsolicitedResponseSender {
+            sender,
+            allow: EnumSet::empty(),
+        }
+    }
+
+    // Check if the user wants the specified unsolicited response.
+    fn filter(&self, r: &UnsolicitedResponse) -> bool {
+       match r {
+            UnsolicitedResponse::Status { .. } => self.allow.contains(UnsolicitedResponseCategory::Status),
+            UnsolicitedResponse::Recent(_) => self.allow.contains(UnsolicitedResponseCategory::Recent),
+            UnsolicitedResponse::Exists(_) => self.allow.contains(UnsolicitedResponseCategory::Exists),
+            UnsolicitedResponse::Expunge(_) => self.allow.contains(UnsolicitedResponseCategory::Expunge),
+            UnsolicitedResponse::Ok { .. } => self.allow.contains(UnsolicitedResponseCategory::Ok),
+            UnsolicitedResponse::No { .. } => self.allow.contains(UnsolicitedResponseCategory::No),
+            UnsolicitedResponse::Bad { .. } => self.allow.contains(UnsolicitedResponseCategory::Bad),
+            UnsolicitedResponse::Bye { .. } => self.allow.contains(UnsolicitedResponseCategory::Bye),
+            UnsolicitedResponse::Fetch { .. } => self.allow.contains(UnsolicitedResponseCategory::Fetch),
+        }
+    }
+
+    // Set the new filter mask, and remove unwanted responses from the current queue.
+    pub fn request(&mut self, rcv: &mpsc::Receiver<UnsolicitedResponse>, mask: EnumSet<UnsolicitedResponseCategory>) {
+        self.allow = mask;
+        let mut keep: Vec<_> = rcv.try_iter().filter(|r| self.filter(r)).collect();
+        keep.drain(..).for_each(|r| self.sender.send(r).unwrap());
+    }
+
+    pub fn send(&mut self, r: UnsolicitedResponse) {
+        if self.filter(&r) {
+            self.sender.send(r).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
The Handle returned by the idle() method now has iter() / iter_keepalive() / iter_timeout() methods that allow iterating over unsolicited responses until an errors occurs. The error is not reported to the user though. Not sure what would be a good way to do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/114)
<!-- Reviewable:end -->
