### PR TITLE
Idle fallible iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bufstream = "0.1"
 imap-proto = "0.7"
 nom = "4.0"
 base64 = "0.10"
+fallible-iterator = "0.2.0"
 
 [dev-dependencies]
 lettre = "0.9"

--- a/src/client.rs
+++ b/src/client.rs
@@ -995,7 +995,8 @@ impl<T: Read + Write> Session<T> {
     ///
     /// See [`extensions::idle::Handle`] for details.
     pub fn idle(&mut self) -> Result<extensions::idle::Handle<T>> {
-        extensions::idle::Handle::make(self)
+        let sender = self.unsolicited_responses_tx.clone();
+        extensions::idle::Handle::make(self, sender)
     }
 
     /// The [`APPEND` command](https://tools.ietf.org/html/rfc3501#section-6.3.11) appends

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ extern crate imap_proto;
 extern crate native_tls;
 extern crate nom;
 extern crate regex;
+extern crate fallible_iterator;
 
 mod parse;
 


### PR DESCRIPTION
- Implemented the IDLE iterator as a FallibleIterator, with proper error handling.
- Fixed timeout handling : the timeout should be handled as starting at the IDLE command, not restarted after each call to next(). This means that IdleIterator and TimeoutIdleIterator must have different next() implementations as the latter has to call set_read_timeout().