### PR TITLE
Implemented new enumerated Capabilities from imap-proto crate.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1620,7 +1620,7 @@ mod tests {
         );
         assert_eq!(capabilities.len(), 4);
         for e in expected_capabilities {
-            assert!(capabilities.has(e));
+            assert!(capabilities.has_str(e));
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -342,7 +342,7 @@ mod tests {
         assert!(recv.try_recv().is_err());
         assert_eq!(capabilities.len(), 4);
         for e in expected_capabilities {
-            assert!(capabilities.has(e));
+            assert!(capabilities.has_str(e));
         }
     }
 
@@ -445,7 +445,7 @@ mod tests {
 
         assert_eq!(capabilities.len(), 4);
         for e in expected_capabilities {
-            assert!(capabilities.has(e));
+            assert!(capabilities.has_str(e));
         }
 
         assert_eq!(

--- a/src/types/capabilities.rs
+++ b/src/types/capabilities.rs
@@ -1,7 +1,9 @@
-use std::borrow::Borrow;
+use imap_proto::types::Capability;
 use std::collections::hash_set::Iter;
 use std::collections::HashSet;
-use std::hash::Hash;
+
+const IMAP4REV1_CAPABILITY: &str = "IMAP4rev1";
+const AUTH_CAPABILITY_PREFIX: &str = "AUTH=";
 
 /// From [section 7.2.1 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-7.2.1).
 ///
@@ -31,21 +33,28 @@ use std::hash::Hash;
 pub struct Capabilities(
     // Note that this field isn't *actually* 'static.
     // Rather, it is tied to the lifetime of the `ZeroCopy` that contains this `Name`.
-    pub(crate) HashSet<&'static str>,
+    pub(crate) HashSet<Capability<'static>>,
 );
 
 impl Capabilities {
     /// Check if the server has the given capability.
-    pub fn has<S: ?Sized>(&self, s: &S) -> bool
-    where
-        for<'a> &'a str: Borrow<S>,
-        S: Hash + Eq,
-    {
+    pub fn has<'a>(&self, s: &Capability<'a>) -> bool {
         self.0.contains(s)
     }
 
+    /// Check if the server has the given capability via str.
+    pub fn has_str(&self, s: &str) -> bool {
+        if s == IMAP4REV1_CAPABILITY {
+            self.has(&Capability::Imap4rev1)
+        } else if s.starts_with(AUTH_CAPABILITY_PREFIX) {
+            self.has(&Capability::Auth(&s[AUTH_CAPABILITY_PREFIX.len()..]))
+        } else {
+            self.has(&Capability::Atom(s))
+        }
+    }
+
     /// Iterate over all the server's capabilities
-    pub fn iter(&self) -> Iter<&str> {
+    pub fn iter(&self) -> Iter<Capability> {
         self.0.iter()
     }
 


### PR DESCRIPTION
This PR exposes the new capability of the underlying imap-proto crate (https://github.com/djc/tokio-imap/pull/47) to parse Capabilities into an enumerated type.

Note that this is not yet ready for merge as it depends on the master of imap-proto, not a currently released version.