### PR TITLE
Placed SSL/TLS dependencies behind a default feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,12 @@ is-it-maintained-open-issues = { repository = "jonhoo/rust-imap" }
 name = "imap"
 path = "src/lib.rs"
 
+[features]
+default = ["ssl"]
+ssl = ["native-tls"]
+
 [dependencies]
-native-tls = "0.2.2"
+native-tls = {version = "0.2.2", optional = true}
 regex = "1.0"
 bufstream = "0.1"
 imap-proto = "0.7"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 extern crate imap;
+#[cfg(feature = "ssl")]
 extern crate native_tls;
 
 fn main() {

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -1,7 +1,8 @@
 extern crate base64;
 extern crate imap;
+#[cfg(feature = "ssl")]
 extern crate native_tls;
-
+#[cfg(feature = "ssl")]
 use native_tls::TlsConnector;
 
 struct GmailOAuth2 {
@@ -20,6 +21,7 @@ impl imap::Authenticator for GmailOAuth2 {
     }
 }
 
+#[cfg(feature = "ssl")]
 fn main() {
     let gmail_auth = GmailOAuth2 {
         user: String::from("sombody@gmail.com"),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use base64;
 use bufstream::BufStream;
+#[cfg(feature = "ssl")]
 use native_tls::{TlsConnector, TlsStream};
 use nom;
 use std::collections::HashSet;
@@ -161,6 +162,7 @@ pub fn connect_insecure<A: ToSocketAddrs>(addr: A) -> Result<Client<TcpStream>> 
 /// let client = imap::connect(("imap.example.org", 993), "imap.example.org", &tls).unwrap();
 /// # }
 /// ```
+#[cfg(feature = "ssl")]
 pub fn connect<A: ToSocketAddrs, S: AsRef<str>>(
     addr: A,
     domain: S,
@@ -185,6 +187,7 @@ impl Client<TcpStream> {
     /// This will upgrade an IMAP client from using a regular TCP connection to use TLS.
     ///
     /// The domain parameter is required to perform hostname verification.
+    #[cfg(feature = "ssl")]
     pub fn secure<S: AsRef<str>>(
         mut self,
         domain: S,

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,9 @@ use std::string::FromUtf8Error;
 use base64::DecodeError;
 use bufstream::IntoInnerError as BufError;
 use imap_proto::Response;
+#[cfg(feature = "ssl")]
 use native_tls::Error as TlsError;
+#[cfg(feature = "ssl")]
 use native_tls::HandshakeError as TlsHandshakeError;
 
 /// A convenience wrapper around `Result` for `imap::Error`.
@@ -22,8 +24,10 @@ pub enum Error {
     /// An `io::Error` that occurred while trying to read or write to a network stream.
     Io(IoError),
     /// An error from the `native_tls` library during the TLS handshake.
+    #[cfg(feature = "ssl")]
     TlsHandshake(TlsHandshakeError<TcpStream>),
     /// An error from the `native_tls` library while managing the socket.
+    #[cfg(feature = "ssl")]
     Tls(TlsError),
     /// A BAD response from the IMAP server.
     Bad(String),
@@ -58,12 +62,14 @@ impl<T> From<BufError<T>> for Error {
     }
 }
 
+#[cfg(feature = "ssl")]
 impl From<TlsHandshakeError<TcpStream>> for Error {
     fn from(err: TlsHandshakeError<TcpStream>) -> Error {
         Error::TlsHandshake(err)
     }
 }
 
+#[cfg(feature = "ssl")]
 impl From<TlsError> for Error {
     fn from(err: TlsError) -> Error {
         Error::Tls(err)
@@ -80,7 +86,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
+            #[cfg(feature = "ssl")]
             Error::Tls(ref e) => fmt::Display::fmt(e, f),
+            #[cfg(feature = "ssl")]
             Error::TlsHandshake(ref e) => fmt::Display::fmt(e, f),
             Error::Validate(ref e) => fmt::Display::fmt(e, f),
             Error::No(ref data) | Error::Bad(ref data) => {
@@ -95,7 +103,9 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Io(ref e) => e.description(),
+            #[cfg(feature = "ssl")]
             Error::Tls(ref e) => e.description(),
+            #[cfg(feature = "ssl")]
             Error::TlsHandshake(ref e) => e.description(),
             Error::Parse(ref e) => e.description(),
             Error::Validate(ref e) => e.description(),
@@ -109,7 +119,9 @@ impl StdError for Error {
     fn cause(&self) -> Option<&StdError> {
         match *self {
             Error::Io(ref e) => Some(e),
+            #[cfg(feature = "ssl")]
             Error::Tls(ref e) => Some(e),
+            #[cfg(feature = "ssl")]
             Error::TlsHandshake(ref e) => Some(e),
             Error::Parse(ParseError::DataNotUtf8(ref e)) => Some(e),
             _ => None,

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -3,6 +3,7 @@
 
 use client::Session;
 use error::{Error, Result};
+#[cfg(feature = "ssl")]
 use native_tls::TlsStream;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
@@ -164,6 +165,7 @@ impl<'a> SetReadTimeout for TcpStream {
     }
 }
 
+#[cfg(feature = "ssl")]
 impl<'a> SetReadTimeout for TlsStream<TcpStream> {
     fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<()> {
         self.get_ref().set_read_timeout(timeout).map_err(Error::Io)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 extern crate base64;
 extern crate bufstream;
 extern crate imap_proto;
+#[cfg(feature = "ssl")]
 extern crate native_tls;
 extern crate nom;
 extern crate regex;

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -1,11 +1,13 @@
 extern crate imap;
 extern crate lettre;
 extern crate lettre_email;
+#[cfg(feature = "ssl")]
 extern crate native_tls;
 
 use lettre::Transport;
 use std::net::TcpStream;
 
+#[cfg(feature = "ssl")]
 fn tls() -> native_tls::TlsConnector {
     native_tls::TlsConnector::builder()
         .danger_accept_invalid_certs(true)
@@ -13,6 +15,7 @@ fn tls() -> native_tls::TlsConnector {
         .unwrap()
 }
 
+#[cfg(feature = "ssl")]
 fn session(user: &str) -> imap::Session<native_tls::TlsStream<TcpStream>> {
     let mut s = imap::connect("127.0.0.1:3993", "imap.example.com", &tls())
         .unwrap()
@@ -22,6 +25,7 @@ fn session(user: &str) -> imap::Session<native_tls::TlsStream<TcpStream>> {
     s
 }
 
+#[cfg(feature = "ssl")]
 fn smtp(user: &str) -> lettre::SmtpTransport {
     let creds = lettre::smtp::authentication::Credentials::new(user.to_string(), user.to_string());
     lettre::SmtpClient::new(
@@ -43,6 +47,7 @@ fn connect_insecure() {
 
 #[test]
 #[ignore]
+#[cfg(feature = "ssl")]
 fn connect_insecure_then_secure() {
     // ignored because of https://github.com/greenmail-mail-test/greenmail/issues/135
     imap::connect_insecure("127.0.0.1:3143")
@@ -52,6 +57,7 @@ fn connect_insecure_then_secure() {
 }
 
 #[test]
+#[cfg(feature = "ssl")]
 fn connect_secure() {
     imap::connect("127.0.0.1:3993", "imap.example.com", &tls()).unwrap();
 }


### PR DESCRIPTION
#123 
This allows usage of the crate without a dependency on SSL/TLS.

By default, the "ssl" feature is included in the dependencies as to not cause any breaking changes.

Note that I have not run any of the functional tests in the test suite.