### PR TITLE
feat: expose read_greeting

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1104,10 +1104,11 @@ impl<T: Read + Write> Session<T> {
 
 impl<T: Read + Write> Connection<T> {
     /// Read the greeting from the connection. Needs to be done after `connect`ing.
+    ///
+    /// Panics if called more than once on the same `Connection`.
     pub fn read_greeting(&mut self) -> Result<Vec<u8>> {
-        if self.greeting_read {
-            return Err(Error::GreetingAlreadyRead);
-        }
+        assert!(!self.greeting_read, "Greeting can only be read once");
+
         let mut v = Vec::new();
         self.readline(&mut v)?;
         self.greeting_read = true;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1099,10 +1099,11 @@ impl<T: Read + Write> Session<T> {
 }
 
 impl<T: Read + Write> Connection<T> {
-    fn read_greeting(&mut self) -> Result<()> {
+    /// Read the greeting from the connection. Needs to be done after `connect`ing.
+    pub fn read_greeting(&mut self) -> Result<Vec<u8>> {
         let mut v = Vec::new();
         self.readline(&mut v)?;
-        Ok(())
+        Ok(v)
     }
 
     fn run_command_and_check_ok(&mut self, command: &str) -> Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
     Validate(ValidateError),
     /// Error appending an e-mail.
     Append,
+    /// Returned when trying to read a greeting multiple times.
+    GreetingAlreadyRead,
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -116,6 +118,7 @@ impl StdError for Error {
             Error::No(_) => "No Response",
             Error::ConnectionLost => "Connection lost",
             Error::Append => "Could not append mail to mailbox",
+            Error::GreetingAlreadyRead => "Greeting can only be read once",
             Error::__Nonexhaustive => "Unknown",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,8 +43,6 @@ pub enum Error {
     Validate(ValidateError),
     /// Error appending an e-mail.
     Append,
-    /// Returned when trying to read a greeting multiple times.
-    GreetingAlreadyRead,
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -118,7 +116,6 @@ impl StdError for Error {
             Error::No(_) => "No Response",
             Error::ConnectionLost => "Connection lost",
             Error::Append => "Could not append mail to mailbox",
-            Error::GreetingAlreadyRead => "Greeting can only be read once",
             Error::__Nonexhaustive => "Unknown",
         }
     }


### PR DESCRIPTION
This is needed when manually using `Client::new()`. 