### PR TITLE
add idle example and add one debug line to idle.rs

### DIFF
--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -1,0 +1,70 @@
+extern crate imap;
+extern crate native_tls;
+use std::env;
+use std::time::Duration;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        eprintln!("need three arguments: imap-server login password");
+    } else {
+        fetch_inbox_and_idle(&args[1], &args[2], &args[3]).unwrap();
+    }
+}
+
+fn fetch_inbox_and_idle(
+    server: &str,
+    login: &str,
+    password: &str,
+) -> imap::error::Result<Option<String>> {
+    let tls = native_tls::TlsConnector::builder().build().unwrap();
+
+    // we pass in the domain twice to check that the server's TLS
+    // certificate is valid for the domain we're connecting to.
+    let mut client = imap::connect((server, 993), server, &tls).unwrap();
+    client.debug = true;
+
+    // the client we have here is unauthenticated.
+    // to do anything useful with the e-mails, we need to log in
+    let mut imap_session = client.login(login, password).map_err(|e| e.0)?;
+
+    // we want to fetch the first email in the INBOX mailbox
+    imap_session.select("INBOX")?;
+
+    // fetch message number 1 in this mailbox, along with its RFC822 field.
+    // RFC 822 dictates the format of the body of e-mails
+    let messages = imap_session.fetch("1", "RFC822")?;
+    println!("got {} messages", messages.len());
+    let message = if let Some(m) = messages.iter().next() {
+        m
+    } else {
+        println!("no messages!");
+        return Ok(None);
+    };
+
+    // extract the message's body
+    let body = message.body().expect("message did not have a body!");
+    let body = std::str::from_utf8(body)
+        .expect("message was not valid utf-8")
+        .to_string();
+
+    println!("got message len={}", body.len());
+    {
+        match imap_session.idle() {
+            Ok(mut idle) => {
+                idle.set_keepalive(Duration::from_secs(20));
+                println!("entering idle wait_keepalive");
+                let res = idle.wait_keepalive();
+                println!("wait_keepalive returned {}", res.is_ok());
+            }
+            Err(err) => {
+                eprintln!("failed to setup idle: {:?}", err);
+            }
+        };
+    }
+
+    // be nice to the server and log out
+    &imap_session.logout()?;
+
+    Ok(Some(body))
+}

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -97,6 +97,9 @@ impl<'a, T: Read + Write + 'a> Handle<'a, T> {
             Err(Error::Io(ref e))
                 if e.kind() == io::ErrorKind::TimedOut || e.kind() == io::ErrorKind::WouldBlock =>
             {
+                if self.session.debug {
+                    eprintln!("idle-restart after error {:?}", e);
+                }
                 // we need to refresh the IDLE connection
                 self.terminate()?;
                 self.init()?;


### PR DESCRIPTION
- new example/idle.rs
- this adds a debug line also highlighting #139 

this example is part of an attempt to debug an issue we have with "hanging idle/imap" threads and DeltaChat's usage of rust-imap.  On my linux machine if i disconnect my WiFi during the wait_keepalive() call of the example, and then reconnect after a while i even get a crash. https://gist.github.com/hpk42/2da33921476ddb57417ce2b501628799

however, this PR is also independently maybe interesting an an example. 