### PR TITLE
When authenticating using SASL XAUTH2 with Gmail fails

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -359,9 +359,15 @@ impl<T: Read + Write> Client<T> {
         // TODO Clean up this code
         loop {
             let mut line = Vec::new();
+
             // explicit match blocks neccessary to convert error to tuple and not bind self too
             // early (see also comment on `login`)
             ok_or_unauth_client_err!(self.readline(&mut line), self);
+
+            // ignore server comments
+            if line.starts_with(b"* ") {
+                continue;
+            }
 
             // Some servers will only send `+\r\n`.
             if line.starts_with(b"+ ") || &line == b"+\r\n" {


### PR DESCRIPTION
When authenticating using SASL XAUTH2 with Gmail the imap library waits forever to read data from the Google servers. I think this is because they send a message explaining that the server is ready even though the imap library expects a response regarding authentication.

Running debug mode looks like this:
```
C: a1 AUTHENTICATE XOAUTH2
S: * OK Gimap ready for requests from IP u21mb6660826edd
S: + 
```

I'm obviously missing tests and such and I don't even know if this is actually a proper fix bug wanted to report the bug and at least share my solution.