### PR TITLE
Re-export Result and Error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ mod client;
 pub use crate::client::*;
 
 pub mod error;
-pub use error::{Result,Error};
+pub use error::{Error, Result};
 
 pub mod extensions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod client;
 pub use crate::client::*;
 
 pub mod error;
+pub use error::{Result,Error};
 
 pub mod extensions;
 


### PR DESCRIPTION
Quite a few crate (serde_json, postgres, reqwest, std::io) re-export the error type from their error module, so I thought it would be good if this crate did as well.
I found myself trying to use imap::Error rather than imap::error::Error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/170)
<!-- Reviewable:end -->
