### PR TITLE
Support HIGHESTMODSEQ and VANISHED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+ - VANISHED support in EXPUNGE responses and unsolicited responses (#172).
 
 ### Changed
+ - MSRV increased to 1.43 for nom6 and bitvec
+ - `expunge` and `uid_expunge` return `Result<Deleted>` instead of `Result<Vec<u32>>`.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ default = ["tls"]
 native-tls = { version = "0.2.2", optional = true }
 regex = "1.0"
 bufstream = "0.1"
-imap-proto = "0.10.0"
-nom = "5.0"
+imap-proto = "0.12.0"
+nom = "6.0"
 base64 = "0.12"
 chrono = "0.4"
 lazy_static = "1.4"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,12 +47,12 @@ jobs:
  - job: msrv
    pool:
      vmImage: ubuntu-latest
-   displayName: "Minimum supported Rust version: 1.40.0"
+   displayName: "Minimum supported Rust version: 1.43.0"
    dependsOn: []
    steps:
      - template: install-rust.yml@templates
        parameters:
-         rust: 1.40.0 # static-assertions (1.37+) and base64 (1.40+)
+         rust: 1.43.0 # nom6 depends on bitvec (1.43+)
      - script: cargo check
        displayName: cargo check
  - job: integration

--- a/src/client.rs
+++ b/src/client.rs
@@ -687,7 +687,7 @@ impl<T: Read + Write> Session<T> {
     /// The [`EXPUNGE` command](https://tools.ietf.org/html/rfc3501#section-6.4.3) permanently
     /// removes all messages that have [`Flag::Deleted`] set from the currently selected mailbox.
     /// The message sequence number of each message that is removed is returned.
-    pub fn expunge(&mut self) -> Result<Vec<Seq>> {
+    pub fn expunge(&mut self) -> Result<Deleted> {
         self.run_command_and_read_response("EXPUNGE")
             .and_then(|lines| parse_expunge(lines, &mut self.unsolicited_responses_tx))
     }
@@ -714,7 +714,7 @@ impl<T: Read + Write> Session<T> {
     ///
     /// Alternatively, the client may fall back to using just [`Session::expunge`], risking the
     /// unintended removal of some messages.
-    pub fn uid_expunge<S: AsRef<str>>(&mut self, uid_set: S) -> Result<Vec<Uid>> {
+    pub fn uid_expunge<S: AsRef<str>>(&mut self, uid_set: S) -> Result<Deleted> {
         self.run_command_and_read_response(&format!("UID EXPUNGE {}", uid_set.as_ref()))
             .and_then(|lines| parse_expunge(lines, &mut self.unsolicited_responses_tx))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1252,10 +1252,10 @@ impl<T: Read + Write> Connection<T> {
             };
 
             let break_with = {
-                use imap_proto::{parse_response, Response, Status};
+                use imap_proto::{Response, Status};
                 let line = &data[line_start..];
 
-                match parse_response(line) {
+                match imap_proto::parser::parse_response(line) {
                     Ok((
                         _,
                         Response::Done {
@@ -1606,6 +1606,7 @@ mod tests {
             permanent_flags: vec![],
             uid_next: Some(2),
             uid_validity: Some(1257842737),
+            highest_mod_seq: None,
         };
         let mailbox_name = "INBOX";
         let command = format!("a1 EXAMINE {}\r\n", quote!(mailbox_name));
@@ -1652,6 +1653,7 @@ mod tests {
             ],
             uid_next: Some(2),
             uid_validity: Some(1257842737),
+            highest_mod_seq: None,
         };
         let mailbox_name = "INBOX";
         let command = format!("a1 SELECT {}\r\n", quote!(mailbox_name));

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,6 @@
-use base64;
 use bufstream::BufStream;
 #[cfg(feature = "tls")]
 use native_tls::{TlsConnector, TlsStream};
-use nom;
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub type Result<T> = result::Result<T, Error>;
 
 /// A set of errors that can occur in the IMAP client
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// An `io::Error` that occurred while trying to read or write to a network stream.
     Io(IoError),
@@ -43,8 +44,6 @@ pub enum Error {
     Validate(ValidateError),
     /// Error appending an e-mail.
     Append,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl From<IoError> for Error {
@@ -99,7 +98,6 @@ impl fmt::Display for Error {
             Error::Bad(ref data) => write!(f, "Bad Response: {}", data),
             Error::ConnectionLost => f.write_str("Connection Lost"),
             Error::Append => f.write_str("Could not append mail to mailbox"),
-            Error::__Nonexhaustive => f.write_str("Unknown"),
         }
     }
 }
@@ -119,7 +117,6 @@ impl StdError for Error {
             Error::No(_) => "No Response",
             Error::ConnectionLost => "Connection lost",
             Error::Append => "Could not append mail to mailbox",
-            Error::__Nonexhaustive => "Unknown",
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -158,6 +158,10 @@ pub fn parse_expunge(
         }
     }
 
+    // If the server sends a VANISHED response then they must only send VANISHED
+    // in lieu of EXPUNGE responses for the rest of this connection, so it is
+    // always one or the other.
+    // https://tools.ietf.org/html/rfc7162#section-3.2.10
     if !vanished.is_empty() {
         Ok(Deleted::from_vanished(vanished))
     } else {

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -1,0 +1,180 @@
+use super::{Seq, Uid};
+use std::ops::RangeInclusive;
+
+/// An enum representing message sequence numbers or UID sequence sets returned
+/// in response to a `EXPUNGE` command.
+///
+/// The `EXPUNGE` command may return several `EXPUNGE` responses referencing
+/// message sequence numbers, or it may return a `VANISHED` response referencing
+/// multiple UID values in a sequence set if the client has enabled
+/// [QRESYNC](https://tools.ietf.org/html/rfc7162#section-3.2.7).
+///
+/// `Deleted` implements some iterators to make it easy to use. If the caller
+/// knows that they should be receiving an `EXPUNGE` or `VANISHED` response,
+/// then they can use [`seqs()`](#method.seqs) to get an iterator over `EXPUNGE`
+/// message sequence numbers, or [`uids()`](#method.uids) to get an iterator over
+/// the `VANISHED` UIDs. As a convenience `Deleted` also implents `IntoIterator`
+/// which just returns an iterator over whatever is contained within.
+///
+/// # Examples
+/// ```no_run
+/// # let domain = "imap.example.com";
+/// # let tls = native_tls::TlsConnector::builder().build().unwrap();
+/// # let client = imap::connect((domain, 993), domain, &tls).unwrap();
+/// # let mut session = client.login("name", "pw").unwrap();
+/// // Iterate over whatever is returned
+/// if let Ok(deleted) = session.expunge() {
+///     for id in &deleted {
+///         // Do something with id
+///     }
+/// }
+///
+/// // Expect a VANISHED response with UIDs
+/// if let Ok(deleted) = session.expunge() {
+///     for uid in deleted.uids() {
+///         // Do something with uid
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub enum Deleted {
+    /// Message sequence numbers given in an `EXPUNGE` response.
+    Expunged(Vec<Seq>),
+    /// Message UIDs given in a `VANISHED` response.
+    Vanished(Vec<RangeInclusive<Uid>>),
+}
+
+impl Deleted {
+    /// Construct a new `Deleted` value from a vector of message sequence
+    /// numbers returned in one or more `EXPUNGE` responses.
+    pub fn from_expunged(v: Vec<u32>) -> Self {
+        Deleted::Expunged(v)
+    }
+
+    /// Construct a new `Deleted` value from a sequence-set of UIDs
+    /// returned in a `VANISHED` response
+    pub fn from_vanished(v: Vec<RangeInclusive<u32>>) -> Self {
+        Deleted::Vanished(v)
+    }
+
+    /// Return an iterator over message sequence numbers from an `EXPUNGE`
+    /// response. If the client is expecting sequence numbers this function
+    /// can be used to ensure only sequence numbers returned in an `EXPUNGE`
+    /// response are processed.
+    pub fn seqs(&self) -> impl Iterator<Item = Seq> + '_ {
+        match self {
+            Deleted::Expunged(s) => s.iter(),
+            Deleted::Vanished(_) => [].iter(),
+        }
+        .copied()
+    }
+
+    /// Return an iterator over UIDs returned in a `VANISHED` response.
+    /// If the client is expecting UIDs this function can be used to ensure
+    /// only UIDs are processed.
+    pub fn uids(&self) -> impl Iterator<Item = Uid> + '_ {
+        match self {
+            Deleted::Expunged(_) => [].iter(),
+            Deleted::Vanished(s) => s.iter(),
+        }
+        .flat_map(|range| range.clone())
+    }
+
+    /// Return if the set is empty
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Deleted::Expunged(v) => v.is_empty(),
+            Deleted::Vanished(v) => v.is_empty(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Deleted {
+    type Item = u32;
+    type IntoIter = Box<dyn Iterator<Item = u32> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Deleted::Expunged(_) => Box::new(self.seqs()),
+            Deleted::Vanished(_) => Box::new(self.uids()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn seq() {
+        let seqs = Deleted::from_expunged(vec![3, 6, 9, 12]);
+        let mut i = seqs.into_iter();
+        assert_eq!(Some(3), i.next());
+        assert_eq!(Some(6), i.next());
+        assert_eq!(Some(9), i.next());
+        assert_eq!(Some(12), i.next());
+        assert_eq!(None, i.next());
+
+        let seqs = Deleted::from_expunged(vec![]);
+        let mut i = seqs.into_iter();
+        assert_eq!(None, i.next());
+    }
+
+    #[test]
+    fn seq_set() {
+        let uids = Deleted::from_vanished(vec![1..=1, 3..=5, 8..=9, 12..=12]);
+        let mut i = uids.into_iter();
+        assert_eq!(Some(1), i.next());
+        assert_eq!(Some(3), i.next());
+        assert_eq!(Some(4), i.next());
+        assert_eq!(Some(5), i.next());
+        assert_eq!(Some(8), i.next());
+        assert_eq!(Some(9), i.next());
+        assert_eq!(Some(12), i.next());
+        assert_eq!(None, i.next());
+
+        let uids = Deleted::from_vanished(vec![]);
+        assert_eq!(None, uids.into_iter().next());
+    }
+
+    #[test]
+    fn seqs() {
+        let seqs: Deleted = Deleted::from_expunged(vec![3, 6, 9, 12]);
+        let mut count: u32 = 0;
+        for seq in seqs.seqs() {
+            count += 3;
+            assert_eq!(seq, count);
+        }
+        assert_eq!(count, 12);
+    }
+
+    #[test]
+    fn uids() {
+        let uids: Deleted = Deleted::from_vanished(vec![1..=6]);
+        let mut count: u32 = 0;
+        for uid in uids.uids() {
+            count += 1;
+            assert_eq!(uid, count);
+        }
+        assert_eq!(count, 6);
+    }
+
+    #[test]
+    fn generic_iteration() {
+        let seqs: Deleted = Deleted::from_expunged(vec![3, 6, 9, 12]);
+        let mut count: u32 = 0;
+        for seq in &seqs {
+            count += 3;
+            assert_eq!(seq, count);
+        }
+        assert_eq!(count, 12);
+
+        let uids: Deleted = Deleted::from_vanished(vec![1..=6]);
+        let mut count: u32 = 0;
+        for uid in &uids {
+            count += 1;
+            assert_eq!(uid, count);
+        }
+        assert_eq!(count, 6);
+    }
+}

--- a/src/types/mailbox.rs
+++ b/src/types/mailbox.rs
@@ -36,7 +36,7 @@ pub struct Mailbox {
     /// the server does not support unique identifiers.
     pub uid_validity: Option<u32>,
 
-    /// The highest mod sequence for this mailboxr. Used with
+    /// The highest mod sequence for this mailbox. Used with
     /// [Conditional STORE](https://tools.ietf.org/html/rfc4551#section-3.1.1).
     pub highest_mod_seq: Option<u64>,
 }

--- a/src/types/mailbox.rs
+++ b/src/types/mailbox.rs
@@ -4,6 +4,7 @@ use std::fmt;
 /// Meta-information about an IMAP mailbox, as returned by
 /// [`SELECT`](https://tools.ietf.org/html/rfc3501#section-6.3.1) and friends.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub struct Mailbox {
     /// Defined flags in the mailbox.  See the description of the [FLAGS
     /// response](https://tools.ietf.org/html/rfc3501#section-7.2.6) for more detail.

--- a/src/types/mailbox.rs
+++ b/src/types/mailbox.rs
@@ -35,6 +35,10 @@ pub struct Mailbox {
     /// The unique identifier validity value.  See [`Uid`] for more details.  If this is missing,
     /// the server does not support unique identifiers.
     pub uid_validity: Option<u32>,
+
+    /// The highest mod sequence for this mailboxr. Used with
+    /// [Conditional STORE](https://tools.ietf.org/html/rfc4551#section-3.1.1).
+    pub highest_mod_seq: Option<u64>,
 }
 
 impl Default for Mailbox {
@@ -47,6 +51,7 @@ impl Default for Mailbox {
             permanent_flags: Vec::new(),
             uid_next: None,
             uid_validity: None,
+            highest_mod_seq: None,
         }
     }
 }
@@ -56,14 +61,15 @@ impl fmt::Display for Mailbox {
         write!(
             f,
             "flags: {:?}, exists: {}, recent: {}, unseen: {:?}, permanent_flags: {:?},\
-             uid_next: {:?}, uid_validity: {:?}",
+             uid_next: {:?}, uid_validity: {:?}, highest_mod_seq: {:?}",
             self.flags,
             self.exists,
             self.recent,
             self.unseen,
             self.permanent_flags,
             self.uid_next,
-            self.uid_validity
+            self.uid_validity,
+            self.highest_mod_seq,
         )
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -172,13 +172,13 @@ impl Flag<'static> {
 impl<'a> fmt::Display for Flag<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Flag::Seen => write!(f, "{}", "\\Seen"),
-            Flag::Answered => write!(f, "{}", "\\Answered"),
-            Flag::Flagged => write!(f, "{}", "\\Flagged"),
-            Flag::Deleted => write!(f, "{}", "\\Deleted"),
-            Flag::Draft => write!(f, "{}", "\\Draft"),
-            Flag::Recent => write!(f, "{}", "\\Recent"),
-            Flag::MayCreate => write!(f, "{}", "\\*"),
+            Flag::Seen => write!(f, "\\Seen"),
+            Flag::Answered => write!(f, "\\Answered"),
+            Flag::Flagged => write!(f, "\\Flagged"),
+            Flag::Deleted => write!(f, "\\Deleted"),
+            Flag::Draft => write!(f, "\\Draft"),
+            Flag::Recent => write!(f, "\\Recent"),
+            Flag::MayCreate => write!(f, "\\*"),
             Flag::Custom(ref s) => write!(f, "{}", s),
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -216,6 +216,9 @@ pub use self::name::{Name, NameAttribute};
 mod capabilities;
 pub use self::capabilities::Capabilities;
 
+mod deleted;
+pub use self::deleted::Deleted;
+
 /// re-exported from imap_proto;
 pub use imap_proto::StatusAttribute;
 
@@ -350,6 +353,7 @@ impl<D> ZeroCopy<D> {
     ///
     /// Only safe if `D` contains no references into the underlying input stream (i.e., the `owned`
     /// passed to `ZeroCopy::new`).
+    #[allow(dead_code)]
     pub(crate) unsafe fn take(self) -> D {
         self.derived
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -277,6 +277,32 @@ pub enum UnsolicitedResponse {
     /// sequence numbers 9, 8, 7, 6, and 5.
     // TODO: the spec doesn't seem to say anything about when these may be received as unsolicited?
     Expunge(Seq),
+
+    /// An unsolicited [`VANISHED` response](https://tools.ietf.org/html/rfc7162#section-3.2.10)
+    /// that reports a sequence-set of `UID`s that have been expunged from the mailbox.
+    ///
+    /// The `VANISHED` response is similar to the `EXPUNGE` response and can be sent wherever
+    /// an `EXPUNGE` response can be sent. It can only be sent by the server if the client
+    /// has enabled [`QRESYNC`](https://tools.ietf.org/html/rfc7162).
+    ///
+    /// The `VANISHED` response has two forms, one with the `EARLIER` tag which is used to
+    /// respond to a `UID FETCH` or `SELECT/EXAMINE` command, and one without an `EARLIER`
+    /// tag, which is used to announce removals within an already selected mailbox.
+    ///
+    /// If using `QRESYNC`, the client can fetch new, updated and deleted `UID`s in a
+    /// single round trip by including the `(CHANGEDSINCE <MODSEQ> VANISHED)`
+    /// modifier to the `UID SEARCH` command, as described in
+    /// [RFC7162](https://tools.ietf.org/html/rfc7162#section-3.1.4). For example
+    /// `UID FETCH 1:* (UID FLAGS) (CHANGEDSINCE 1234 VANISHED)` would return `FETCH`
+    /// results for all `UID`s added or modified since `MODSEQ` `1234`. Deleted `UID`s
+    /// will be present as a `VANISHED` response in the `Session::unsolicited_responses`
+    /// channel.
+    Vanished {
+        /// Whether the `EARLIER` tag was set on the response
+        earlier: bool,
+        /// The list of `UID`s which have been removed
+        uids: Vec<std::ops::RangeInclusive<u32>>,
+    },
 }
 
 /// This type wraps an input stream and a type that was constructed by parsing that input stream,


### PR DESCRIPTION
This adds support for imap-proto `ResponseCode::HighestModSeq(u64)` and the `VANISHED` response described in RFC 7162 (QRESYNC). With these extensions, it is possible to synchronize a mailbox in a single round trip using `UID FETCH` and passing a modifier `(CHANGEDSINCE <MODSEQ> VANISHED)`. Only modifications and new messages since `<MODSEQ>` will be returned, and deleted messages will be returned in a `VANISHED` response on the `unsolicited_responses` channel.

Technically, if `QRESYNC` is enabled then `VANISHED` responses will be sent to `EXPUNGE` commands. Presently these will show up on the `unsolicited_responses` channel even though they are directly a response to a command. I wasn't sure what the best way to handle this would be in `parse_expunge()`, and commented to this effect in `parse_vanished_test()`, and the test is constructed in a way to verify that `parse_expunge()` succeeds under this condition, and the `VANISHED` response is available in the `unsolicited_responses` channel.

I also fixed clippy warnings. One of them I actually introduced (useless format string) - sorry. The other one is for the [manual_non_exhaustive lint](https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive). I separated them out into different commits so you can see them in isolation.

I am happy to revise this if you would like, particularly if you have a preference for what to do in `parse_expunge()`. I did experiment with expanding the `VANISHED` uid sequence-set out into a `Vec<u32>`, but it's kind of ugly, and also kind of dangerous for very large ranges, so I erred on the side of at least being consistent and having these responses always show up on the `unsolicited_responses` channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/172)
<!-- Reviewable:end -->
