### PR TITLE
CI: Only install components when needed.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,18 +6,23 @@ jobs:
        Linux-stable:
          vmImage: ubuntu-latest
          rust: stable
+         components: []
        Linux-beta:
          vmImage: ubuntu-latest
          rust: beta
+         components: [rustfmt, clippy]
        Linux-nightly:
          vmImage: ubuntu-latest
          rust: nightly
+         components: []
        MacOS:
          vmImage: macOS-10.14
          rust: stable
+         components: []
        Windows:
          vmImage: windows-2019
          rust: stable
+         components: []
    continueOnError: $[eq(variables.rust, 'nightly')]
    pool:
      vmImage: $(vmImage)
@@ -25,9 +30,7 @@ jobs:
      - template: install-rust.yml@templates
        parameters:
          rust: $(rust)
-         components:
-           - rustfmt
-           - clippy
+         components: $(components)
      - script: cargo check --all-targets
        displayName: cargo check
      - script: cargo test --examples

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,23 +6,18 @@ jobs:
        Linux-stable:
          vmImage: ubuntu-latest
          rust: stable
-         components: []
        Linux-beta:
          vmImage: ubuntu-latest
          rust: beta
-         components: [rustfmt, clippy]
        Linux-nightly:
          vmImage: ubuntu-latest
          rust: nightly
-         components: []
        MacOS:
          vmImage: macOS-10.14
          rust: stable
-         components: []
        Windows:
          vmImage: windows-2019
          rust: stable
-         components: []
    continueOnError: $[eq(variables.rust, 'nightly')]
    pool:
      vmImage: $(vmImage)
@@ -30,7 +25,6 @@ jobs:
      - template: install-rust.yml@templates
        parameters:
          rust: $(rust)
-         components: $(components)
      - script: cargo check --all-targets
        displayName: cargo check
      - script: cargo test --examples
@@ -39,10 +33,16 @@ jobs:
        displayName: cargo test --doc
      - script: cargo test --lib
        displayName: cargo test --lib
-     - script: cargo fmt --all -- --check
+     - script: |
+         set -e
+         rustup component add rustfmt
+         cargo fmt --all -- --check
        displayName: cargo fmt --check
        condition: and(eq( variables['rust'], 'beta' ), eq( variables['Agent.OS'], 'Linux' ))
-     - script: cargo clippy -- -D warnings
+     - script: |
+         set -e
+         rustup component add clippy
+         cargo clippy -- -D warnings
        displayName: cargo clippy
        condition: and(eq( variables['rust'], 'beta' ), eq( variables['Agent.OS'], 'Linux' ))
  # This represents the minimum Rust version supported.


### PR DESCRIPTION
Nightly pipeline is failing on missing rustfmt, but we don't actually need it except for the beta version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/173)
<!-- Reviewable:end -->
