### PR TITLE
feat: allow setting sent date on APPEND

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1122,7 +1122,7 @@ impl<T: Read + Write> Session<T> {
         mailbox: S,
         content: B,
         flags: &[Flag<'_>],
-        date: Option<DateTime<FixedOffset>>,
+        date: impl Into<Option<DateTime<FixedOffset>>>,
     ) -> Result<()> {
         let content = content.as_ref();
         let flagstr = flags
@@ -1131,7 +1131,7 @@ impl<T: Read + Write> Session<T> {
             .map(|f| f.to_string())
             .collect::<Vec<String>>()
             .join(" ");
-        let datestr = match date {
+        let datestr = match date.into() {
             Some(date) => format!(" \"{}\"", date.format("%d-%h-%Y %T %z")),
             None => "".to_string(),
         };

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use base64;
 use bufstream::BufStream;
+use chrono::{DateTime, FixedOffset};
 #[cfg(feature = "tls")]
 use native_tls::{TlsConnector, TlsStream};
 use nom;
@@ -1121,7 +1122,7 @@ impl<T: Read + Write> Session<T> {
         mailbox: S,
         content: B,
         flags: &[Flag<'_>],
-        date: Option<chrono::NaiveDateTime>,
+        date: Option<DateTime<FixedOffset>>,
     ) -> Result<()> {
         let content = content.as_ref();
         let flagstr = flags
@@ -1131,7 +1132,7 @@ impl<T: Read + Write> Session<T> {
             .collect::<Vec<String>>()
             .join(" ");
         let datestr = match date {
-            Some(date) => format!(" \"{} +0000\"", date.format("%d-%h-%Y %T")),
+            Some(date) => format!(" \"{}\"", date.format("%d-%h-%Y %T %z")),
             None => "".to_string(),
         };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1110,6 +1110,12 @@ impl<T: Read + Write> Session<T> {
     ///
     /// The [`\Recent` flag](https://tools.ietf.org/html/rfc3501#section-2.3.2) is not
     /// allowed as an argument to `APPEND` and will be filtered out if present in `flags`.
+    ///
+    /// Pass a date in order to set the date that the message was originally sent.
+    ///
+    /// > If a date-time is specified, the internal date SHOULD be set in
+    /// > the resulting message; otherwise, the internal date of the
+    /// > resulting message is set to the current date and time by default.
     pub fn append_with_flags_and_date<S: AsRef<str>, B: AsRef<[u8]>>(
         &mut self,
         mailbox: S,
@@ -1124,13 +1130,6 @@ impl<T: Read + Write> Session<T> {
             .map(|f| f.to_string())
             .collect::<Vec<String>>()
             .join(" ");
-
-        // date-time       = DQUOTE date-day-fixed "-" date-month "-" date-year SP time SP zone DQUOTE
-        // date-day-fixed  = (SP DIGIT) / 2DIGIT
-        // date-month      = "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" / "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
-        // date-year       = 4DIGIT
-        // time            = 2DIGIT ":" 2DIGIT ":" 2DIGIT
-        // zone            = ("+" / "-") 4DIGIT
         let datestr = match date {
             Some(date) => format!(" \"{} +0000\"", date.format("%d-%h-%Y %T")),
             None => "".to_string(),

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -1,8 +1,10 @@
+extern crate chrono;
 extern crate imap;
 extern crate lettre;
 extern crate lettre_email;
 extern crate native_tls;
 
+use chrono::{FixedOffset, TimeZone};
 use lettre::Transport;
 use std::net::TcpStream;
 
@@ -315,6 +317,68 @@ fn append_with_flags() {
     assert_eq!(fetch.uid, Some(uid));
     let e = fetch.envelope().unwrap();
     assert_eq!(e.subject, Some(&b"My third e-mail"[..]));
+
+    // check the flags
+    let setflags = fetch.flags();
+    assert!(setflags.contains(&Flag::Seen));
+    assert!(setflags.contains(&Flag::Flagged));
+
+    // and let's delete it to clean up
+    c.uid_store(format!("{}", uid), "+FLAGS (\\Deleted)")
+        .unwrap();
+    c.expunge().unwrap();
+
+    // the e-mail should be gone now
+    let inbox = c.search("ALL").unwrap();
+    assert_eq!(inbox.len(), 0);
+}
+
+#[test]
+#[ignore]
+fn append_with_flags_and_date() {
+    use imap::types::Flag;
+
+    let to = "inbox-append2@localhost";
+
+    // make a message to append
+    let e: lettre::SendableEmail = lettre_email::Email::builder()
+        .from("sender@localhost")
+        .to(to)
+        .subject("My third e-mail")
+        .text("Hello world")
+        .build()
+        .unwrap()
+        .into();
+
+    // connect
+    let mut c = session(to);
+    let mbox = "INBOX";
+    c.select(mbox).unwrap();
+    //append
+    let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
+    let date = FixedOffset::east(8 * 3600)
+        .ymd(2020, 12, 13)
+        .and_hms(13, 36, 36);
+    c.append_with_flags_and_date(mbox, e.message_to_string().unwrap(), flags, Some(date))
+        .unwrap();
+
+    // now we should see the e-mail!
+    let inbox = c.uid_search("ALL").unwrap();
+    // and the one message should have the first message sequence number
+    assert_eq!(inbox.len(), 1);
+    let uid = inbox.into_iter().next().unwrap();
+
+    // fetch the e-mail
+    let fetch = c.uid_fetch(format!("{}", uid), "(ALL UID)").unwrap();
+    assert_eq!(fetch.len(), 1);
+    let fetch = &fetch[0];
+    assert_eq!(fetch.uid, Some(uid));
+    let e = fetch.envelope().unwrap();
+    assert_eq!(e.subject, Some(&b"My third e-mail"[..]));
+    assert_eq!(
+        std::str::from_utf8(e.date.unwrap()).expect("Mail has date"),
+        "Sun, 13 Dec 2020 05:36:36 +0000 (GMT)"
+    );
 
     // check the flags
     let setflags = fetch.flags();

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -334,11 +334,10 @@ fn append_with_flags() {
 }
 
 #[test]
-#[ignore]
 fn append_with_flags_and_date() {
     use imap::types::Flag;
 
-    let to = "inbox-append2@localhost";
+    let to = "inbox-append3@localhost";
 
     // make a message to append
     let e: lettre::SendableEmail = lettre_email::Email::builder()
@@ -354,7 +353,7 @@ fn append_with_flags_and_date() {
     let mut c = session(to);
     let mbox = "INBOX";
     c.select(mbox).unwrap();
-    //append
+    // append
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
     let date = FixedOffset::east(8 * 3600)
         .ymd(2020, 12, 13)
@@ -373,17 +372,7 @@ fn append_with_flags_and_date() {
     assert_eq!(fetch.len(), 1);
     let fetch = &fetch[0];
     assert_eq!(fetch.uid, Some(uid));
-    let e = fetch.envelope().unwrap();
-    assert_eq!(e.subject, Some(&b"My third e-mail"[..]));
-    assert_eq!(
-        std::str::from_utf8(e.date.unwrap()).expect("Mail has date"),
-        "Sun, 13 Dec 2020 05:36:36 +0000 (GMT)"
-    );
-
-    // check the flags
-    let setflags = fetch.flags();
-    assert!(setflags.contains(&Flag::Seen));
-    assert!(setflags.contains(&Flag::Flagged));
+    assert_eq!(fetch.internal_date(), Some(date));
 
     // and let's delete it to clean up
     c.uid_store(format!("{}", uid), "+FLAGS (\\Deleted)")


### PR DESCRIPTION
References issue #60

Followed syntax of (date-time token) http://www.faqs.org/rfcs/rfc3501.html

I followed the pattern of `append` calling `append_with_flags` calling `append_with_flags_and_date`.

- [x] existing tests passes
- [x] update fn docs
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/174)
<!-- Reviewable:end -->
