### PR TITLE
refactor: squash append command

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -85,6 +85,7 @@ pub struct Connection<T: Read + Write> {
 }
 
 /// A builder for the append command
+#[must_use]
 pub struct AppendCmd<'a, T: Read + Write> {
     session: &'a mut Session<T>,
     content: &'a [u8],
@@ -126,7 +127,6 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
     }
 
     /// Run command
-    #[must_use = "always run a command once options are configured"]
     pub fn run(&mut self) -> Result<()> {
         let flagstr = self
             .flags

--- a/src/client.rs
+++ b/src/client.rs
@@ -93,6 +93,41 @@ pub struct AppendOptions<'a> {
     pub date: Option<DateTime<FixedOffset>>,
 }
 
+/// A builder for the append command
+#[derive(Default)]
+pub struct AppendCmd<'a> {
+    flags: Vec<&'a Flag<'a>>,
+    date: Option<DateTime<FixedOffset>>,
+}
+
+impl<'a> AppendCmd<'a> {
+    /// Create a new AppendCmd builder
+    pub fn create() -> Self {
+        Self::default()
+    }
+
+    /// Append a flag
+    pub fn flag(&mut self, flag: &'a Flag<'a>) -> &mut Self {
+        self.flags.push(flag);
+        self
+    }
+
+    /// Set the internal date
+    pub fn internal_date(&mut self, date: DateTime<FixedOffset>) -> &mut Self {
+        self.date = Some(date);
+        self
+    }
+}
+
+impl<'a> Into<AppendOptions<'a>> for AppendCmd<'a> {
+    fn into(self) -> AppendOptions<'a> {
+        AppendOptions {
+            flags: Some(&self.flags[..]),
+            date: self.date,
+        }
+    }
+}
+
 // `Deref` instances are so we can make use of the same underlying primitives in `Client` and
 // `Session`
 impl<T: Read + Write> Deref for Client<T> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,7 +94,16 @@ pub struct AppendCmd<'a, T: Read + Write> {
 }
 
 impl<'a, T: Read + Write> AppendCmd<'a, T> {
-    /// Append a flag
+    /// The [`APPEND` command](https://tools.ietf.org/html/rfc3501#section-6.3.11) can take
+    /// an optional FLAGS parameter to set the flags on the new message.
+    ///
+    /// > If a flag parenthesized list is specified, the flags SHOULD be set
+    /// > in the resulting message; otherwise, the flag list of the
+    /// > resulting message is set to empty by default.  In either case, the
+    /// > Recent flag is also set.
+    ///
+    /// The [`\Recent` flag](https://tools.ietf.org/html/rfc3501#section-2.3.2) is not
+    /// allowed as an argument to `APPEND` and will be filtered out if present in `flags`.
     pub fn flag(&mut self, flag: Flag<'a>) -> &mut Self {
         self.flags.push(flag);
         self
@@ -106,14 +115,18 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
         self
     }
 
-    /// Set the internal date
+    /// Pass a date in order to set the date that the message was originally sent.
+    ///
+    /// > If a date-time is specified, the internal date SHOULD be set in
+    /// > the resulting message; otherwise, the internal date of the
+    /// > resulting message is set to the current date and time by default.
     pub fn internal_date(&mut self, date: DateTime<FixedOffset>) -> &mut Self {
         self.date = Some(date);
         self
     }
 
-    /// Run command when set up
-    #[must_use]
+    /// Run command
+    #[must_use = "always run a command once options are configured"]
     pub fn run(&mut self) -> Result<()> {
         let flagstr = self
             .flags
@@ -1144,26 +1157,6 @@ impl<T: Read + Write> Session<T> {
     /// `EXISTS` response.  If the server does not do so, the client MAY issue a `NOOP` command (or
     /// failing that, a `CHECK` command) after one or more `APPEND` commands.
     ///
-    /// -- TODO merge docs possibly move to AppendOptions
-    ///
-    /// The [`APPEND` command](https://tools.ietf.org/html/rfc3501#section-6.3.11) can take
-    /// an optional FLAGS parameter to set the flags on the new message.
-    ///
-    /// > If a flag parenthesized list is specified, the flags SHOULD be set
-    /// > in the resulting message; otherwise, the flag list of the
-    /// > resulting message is set to empty by default.  In either case, the
-    /// > Recent flag is also set.
-    ///
-    /// The [`\Recent` flag](https://tools.ietf.org/html/rfc3501#section-2.3.2) is not
-    /// allowed as an argument to `APPEND` and will be filtered out if present in `flags`.
-    ///
-    /// -- TODO merge docs possibly move to AppendOptions
-    ///
-    /// Pass a date in order to set the date that the message was originally sent.
-    ///
-    /// > If a date-time is specified, the internal date SHOULD be set in
-    /// > the resulting message; otherwise, the internal date of the
-    /// > resulting message is set to the current date and time by default.
     pub fn append<'a>(&'a mut self, mailbox: &'a str, content: &'a [u8]) -> AppendCmd<'a, T> {
         AppendCmd {
             session: self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,7 +110,7 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
         self
     }
 
-    /// Append an array of flags
+    /// Set multiple flags at once.
     pub fn flags(&mut self, flags: impl IntoIterator<Item = Flag<'a>>) -> &mut Self {
         self.flags.extend(flags);
         self
@@ -126,7 +126,10 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
         self
     }
 
-    /// Run command
+    /// Finishes up the command and executes it.
+    ///
+    /// Note: be sure to set flags and optional date before you
+    /// finish the command.
     pub fn finish(&mut self) -> Result<()> {
         let flagstr = self
             .flags

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,6 +100,12 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
         self
     }
 
+    /// Append an array of flags
+    pub fn flags(&mut self, flags: &'a [Flag<'a>]) -> &mut Self {
+        self.flags.append(&mut flags.to_vec());
+        self
+    }
+
     /// Set the internal date
     pub fn internal_date(&mut self, date: DateTime<FixedOffset>) -> &mut Self {
         self.date = Some(date);

--- a/src/client.rs
+++ b/src/client.rs
@@ -127,7 +127,7 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
     }
 
     /// Run command
-    pub fn run(&mut self) -> Result<()> {
+    pub fn finish(&mut self) -> Result<()> {
         let flagstr = self
             .flags
             .clone()

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,13 +89,13 @@ pub struct AppendCmd<'a, T: Read + Write> {
     session: &'a mut Session<T>,
     content: &'a [u8],
     mailbox: &'a str,
-    flags: Vec<&'a Flag<'a>>,
+    flags: Vec<Flag<'a>>,
     date: Option<DateTime<FixedOffset>>,
 }
 
 impl<'a, T: Read + Write> AppendCmd<'a, T> {
     /// Append a flag
-    pub fn flag(&mut self, flag: &'a Flag<'a>) -> &mut Self {
+    pub fn flag(&mut self, flag: Flag<'a>) -> &mut Self {
         self.flags.push(flag);
         self
     }
@@ -108,11 +108,12 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
 
     /// Run command when set up
     #[must_use]
-    pub fn run(&self) -> Result<()> {
+    pub fn run(&mut self) -> Result<()> {
         let flagstr = self
             .flags
+            .clone()
             .into_iter()
-            .filter(|f| **f != Flag::Recent)
+            .filter(|f| *f != Flag::Recent)
             .map(|f| f.to_string())
             .collect::<Vec<String>>()
             .join(" ");
@@ -1157,15 +1158,11 @@ impl<T: Read + Write> Session<T> {
     /// > If a date-time is specified, the internal date SHOULD be set in
     /// > the resulting message; otherwise, the internal date of the
     /// > resulting message is set to the current date and time by default.
-    pub fn append<'a, S: AsRef<str>, B: AsRef<[u8]>>(
-        &mut self,
-        mailbox: S,
-        content: B,
-    ) -> AppendCmd<'a, T> {
+    pub fn append<'a>(&'a mut self, mailbox: &'a str, content: &'a [u8]) -> AppendCmd<'a, T> {
         AppendCmd {
             session: self,
-            content: content.as_ref(),
-            mailbox: mailbox.as_ref(),
+            content,
+            mailbox,
             flags: Vec::new(),
             date: None,
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,7 +86,7 @@ pub struct Connection<T: Read + Write> {
 
 /// A builder for the append command
 pub struct AppendCmd<'a, T: Read + Write> {
-    session: &'a Session<T>,
+    session: &'a mut Session<T>,
     content: &'a [u8],
     mailbox: &'a str,
     flags: Vec<&'a Flag<'a>>,
@@ -1163,7 +1163,7 @@ impl<T: Read + Write> Session<T> {
         content: B,
     ) -> AppendCmd<'a, T> {
         AppendCmd {
-            session: &self,
+            session: self,
             content: content.as_ref(),
             mailbox: mailbox.as_ref(),
             flags: Vec::new(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,8 +110,8 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
     }
 
     /// Append an array of flags
-    pub fn flags(&mut self, flags: &'a [Flag<'a>]) -> &mut Self {
-        self.flags.append(&mut flags.to_vec());
+    pub fn flags(&mut self, flags: impl IntoIterator<Item = Flag<'a>>) -> &mut Self {
+        self.flags.extend(flags);
         self
     }
 

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -302,7 +302,7 @@ fn append_with_flags() {
     let mbox = "INBOX";
     c.select(mbox).unwrap();
     //append
-    let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
+    let flags = vec![Flag::Seen, Flag::Flagged];
     c.append(mbox, e.message_to_string().unwrap().as_bytes())
         .flags(flags)
         .finish()

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -253,7 +253,8 @@ fn append() {
     let mbox = "INBOX";
     c.select(mbox).unwrap();
     //append
-    c.append(mbox, e.message_to_string().unwrap()).unwrap();
+    c.append(mbox, e.message_to_string().unwrap(), None)
+        .unwrap();
 
     // now we should see the e-mail!
     let inbox = c.uid_search("ALL").unwrap();
@@ -301,8 +302,15 @@ fn append_with_flags() {
     c.select(mbox).unwrap();
     //append
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
-    c.append_with_flags(mbox, e.message_to_string().unwrap(), flags)
-        .unwrap();
+    c.append(
+        mbox,
+        e.message_to_string().unwrap(),
+        imap::AppendOptions {
+            flags: Some(flags),
+            date: None,
+        },
+    )
+    .unwrap();
 
     // now we should see the e-mail!
     let inbox = c.uid_search("ALL").unwrap();
@@ -358,8 +366,15 @@ fn append_with_flags_and_date() {
     let date = FixedOffset::east(8 * 3600)
         .ymd(2020, 12, 13)
         .and_hms(13, 36, 36);
-    c.append_with_flags_and_date(mbox, e.message_to_string().unwrap(), flags, Some(date))
-        .unwrap();
+    c.append(
+        mbox,
+        e.message_to_string().unwrap(),
+        imap::AppendOptions {
+            flags: Some(flags),
+            date: Some(date),
+        },
+    )
+    .unwrap();
 
     // now we should see the e-mail!
     let inbox = c.uid_search("ALL").unwrap();

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -253,7 +253,8 @@ fn append() {
     let mbox = "INBOX";
     c.select(mbox).unwrap();
     //append
-    c.append(mbox, e.message_to_string().unwrap(), None)
+    c.append(mbox, e.message_to_string().unwrap())
+        .run()
         .unwrap();
 
     // now we should see the e-mail!
@@ -302,15 +303,11 @@ fn append_with_flags() {
     c.select(mbox).unwrap();
     //append
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
-    c.append(
-        mbox,
-        e.message_to_string().unwrap(),
-        imap::AppendOptions {
-            flags: Some(flags),
-            date: None,
-        },
-    )
-    .unwrap();
+    c.append(mbox, e.message_to_string().unwrap())
+        .flag(Flag::Seen)
+        .flag(Flag::Flagged)
+        .run()
+        .unwrap();
 
     // now we should see the e-mail!
     let inbox = c.uid_search("ALL").unwrap();
@@ -366,15 +363,12 @@ fn append_with_flags_and_date() {
     let date = FixedOffset::east(8 * 3600)
         .ymd(2020, 12, 13)
         .and_hms(13, 36, 36);
-    c.append(
-        mbox,
-        e.message_to_string().unwrap(),
-        imap::AppendOptions {
-            flags: Some(flags),
-            date: Some(date),
-        },
-    )
-    .unwrap();
+    c.append(mbox, e.message_to_string().unwrap())
+        .flag(Flag::Seen)
+        .flag(Flag::Flagged)
+        .internal_date(date)
+        .run()
+        .unwrap();
 
     // now we should see the e-mail!
     let inbox = c.uid_search("ALL").unwrap();

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -253,7 +253,7 @@ fn append() {
     let mbox = "INBOX";
     c.select(mbox).unwrap();
     //append
-    c.append(mbox, e.message_to_string().unwrap())
+    c.append(mbox, e.message_to_string().unwrap().as_bytes())
         .run()
         .unwrap();
 
@@ -303,7 +303,7 @@ fn append_with_flags() {
     c.select(mbox).unwrap();
     //append
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
-    c.append(mbox, e.message_to_string().unwrap())
+    c.append(mbox, e.message_to_string().unwrap().as_bytes())
         .flag(Flag::Seen)
         .flag(Flag::Flagged)
         .run()
@@ -359,11 +359,10 @@ fn append_with_flags_and_date() {
     let mbox = "INBOX";
     c.select(mbox).unwrap();
     // append
-    let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
     let date = FixedOffset::east(8 * 3600)
         .ymd(2020, 12, 13)
         .and_hms(13, 36, 36);
-    c.append(mbox, e.message_to_string().unwrap())
+    c.append(mbox, e.message_to_string().unwrap().as_bytes())
         .flag(Flag::Seen)
         .flag(Flag::Flagged)
         .internal_date(date)

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -254,7 +254,7 @@ fn append() {
     c.select(mbox).unwrap();
     //append
     c.append(mbox, e.message_to_string().unwrap().as_bytes())
-        .run()
+        .finish()
         .unwrap();
 
     // now we should see the e-mail!
@@ -305,7 +305,7 @@ fn append_with_flags() {
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
     c.append(mbox, e.message_to_string().unwrap().as_bytes())
         .flags(flags)
-        .run()
+        .finish()
         .unwrap();
 
     // now we should see the e-mail!
@@ -365,7 +365,7 @@ fn append_with_flags_and_date() {
         .flag(Flag::Seen)
         .flag(Flag::Flagged)
         .internal_date(date)
-        .run()
+        .finish()
         .unwrap();
 
     // now we should see the e-mail!

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -304,8 +304,7 @@ fn append_with_flags() {
     //append
     let flags: &[Flag] = &[Flag::Seen, Flag::Flagged];
     c.append(mbox, e.message_to_string().unwrap().as_bytes())
-        .flag(Flag::Seen)
-        .flag(Flag::Flagged)
+        .flags(flags)
         .run()
         .unwrap();
 


### PR DESCRIPTION
This is an attempt to simplify append by squashing the three variants into to one command + an options struct `AppendOptions`.

This PR also provides a command builder `AppendCmd` to simplify construction of the options struct as [suggested here](https://github.com/jonhoo/rust-imap/pull/174#issuecomment-745000597) and onwards:

```rust
session.append(
  mbox,
  e.message_to_string().unwrap(),
  AppendCmd::new()
     .flag(Flag::Seen)
     .internal_date(&date)
);
```

- [x] tests
- [x] update docs

---

Thoughts not related to what is implemented:

- If `AppendCmd` builds options maybe it should be called `AppendOptionsBuilder` (very long)

- and if so what `AppendCmd` look like:

```rust
struct AppendCmd {
  mbox: ..,
  content: ..,
  // impl
  pub fn run(&self) -> ...;
  pub fn with_options(&self) -> AppendOptionsBuilder {
     AppendOptionsBuilder {
         cmd: &self,
         flags: ...
         internal_date: ...
     }
     // impl
     fn run(&self) {
         self.cmd.run()
     }
  } 
}

session.append(mbox, e.message_to_string().unwrap()) |> AppendCmd
  .with_options() |> AppendOptionsBuilder
  .flag(Flag::Seen) |> AppendOptionsBuilder
  .internal_date(date) |> AppendOptionsBuilder
  .run()
```

Or maybe just combine them into to one. Compared to the existing api aside from the conveinince of builders there is an extra call to `run()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/175)
<!-- Reviewable:end -->
