### PR TITLE
Handle unsolicited "* OK Searched 91% of the mailbox, ETA 0:01" message

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -331,6 +331,9 @@ fn handle_unilateral<'a>(
         Response::Expunge(n) => {
             unsolicited.send(UnsolicitedResponse::Expunge(n)).unwrap();
         }
+        Response::Data {status, code, information} if imap_proto::Status::Ok == status && code.is_none() => {
+            unsolicited.send(UnsolicitedResponse::Uncategorised(information.unwrap_or("").to_string())).unwrap();
+        }
         res => {
             return Some(res);
         }
@@ -437,6 +440,16 @@ mod tests {
         assert_eq!(fetches.len(), 1);
         assert_eq!(fetches[0].message, 37);
         assert_eq!(fetches[0].uid, Some(74));
+    }
+
+    #[test]
+    fn parse_uncategorised_ok() {
+        let lines = b"\
+        * OK Searched 91% of the mailbox, ETA 0:01\r\n";
+        let (mut send, recv) = mpsc::channel();
+        parse_fetches(lines.to_vec(), &mut send).unwrap();
+        assert_eq!(recv.try_recv(), Ok(UnsolicitedResponse::Uncategorised("Searched 91% of the mailbox, ETA 0:01".to_string())));
+
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -277,6 +277,10 @@ pub enum UnsolicitedResponse {
     /// sequence numbers 9, 8, 7, 6, and 5.
     // TODO: the spec doesn't seem to say anything about when these may be received as unsolicited?
     Expunge(Seq),
+    /// An uncategorised response - one which has no code associated with it, just a text
+    /// Dovecot is known to send a status message with an ETA for a long running fetch which
+    /// has no [] enclosed code.
+    Uncategorised(String),
 }
 
 /// This type wraps an input stream and a type that was constructed by parsing that input stream,


### PR DESCRIPTION
When fetching a large number of UIDs, rust-imap would sometimes produce an error.

Looking into it, dovecot sometimes responds with

* OK Searched 91% of the mailbox, ETA 0:01

which is not handled when expecting a response to a Fetch message.

This is a small change to handle this case. I have made it quite explicit - it only handles an OK status with no code, as I'm not sure whether other messages which have an unknown code (but do contain a code) would be better handled by returning an error as is currently the case.

