### PR TITLE
Add vendored feature to set native-tls/vendored

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["email", "network-programming"]
 
 [features]
 tls = ["native-tls"]
+vendored = ["tls", "native-tls/vendored"]
 default = ["tls"]
 
 [dependencies]


### PR DESCRIPTION
Proposal, because I need openssl-sys (so native-tls) to have the vendored feature
With this feature, we can allow cross-compilation for rust-imap (tested with android targets), and allow to link statically with env OPENSSL_STATIC=1

Note that this feature will not be set by default, so it's not a breaking change.
(I named this feature `vendored` because native-tls did the same thing to enable openssl-sys vendored feature)

Thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/183)
<!-- Reviewable:end -->
