### PR TITLE
Try handle unsolicited & clippy

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1459,7 +1459,7 @@ impl<T: Read + Write> Connection<T> {
             // Remove CRLF
             let len = into.len();
             let line = &into[(len - read)..(len - 2)];
-            eprint!("S: {}\n", String::from_utf8_lossy(line));
+            eprintln!("S: {}", String::from_utf8_lossy(line));
         }
 
         Ok(read)
@@ -1475,7 +1475,7 @@ impl<T: Read + Write> Connection<T> {
         self.stream.write_all(&[CR, LF])?;
         self.stream.flush()?;
         if self.debug {
-            eprint!("C: {}\n", String::from_utf8(buf.to_vec()).unwrap());
+            eprintln!("C: {}", String::from_utf8(buf.to_vec()).unwrap());
         }
         Ok(())
     }

--- a/src/extensions/metadata.rs
+++ b/src/extensions/metadata.rs
@@ -34,7 +34,7 @@ impl CmdListItemFormat for Metadata {
             self.value
                 .as_ref()
                 .map(|v| validate_str(v.as_str()).unwrap())
-                .unwrap_or("NIL".to_string())
+                .unwrap_or_else(|| "NIL".to_string())
         )
     }
 }
@@ -69,9 +69,9 @@ impl Default for MetadataDepth {
 impl MetadataDepth {
     fn depth_str<'a>(self) -> &'a str {
         match self {
-            MetadataDepth::Zero => return "0",
-            MetadataDepth::One => return "1",
-            MetadataDepth::Infinity => return "infinity",
+            MetadataDepth::Zero => "0",
+            MetadataDepth::One => "1",
+            MetadataDepth::Infinity => "infinity",
         }
     }
 }
@@ -175,18 +175,15 @@ impl<T: Read + Write> Session<T> {
         let s = v.as_slice().join(" ");
         let mut command = format!("GETMETADATA (DEPTH {}", depth.depth_str());
 
-        match maxsize {
-            Some(size) => {
-                command.push_str(format!(" MAXSIZE {}", size).as_str());
-            }
-            _ => {}
+        if let Some(size) = maxsize {
+            command.push_str(format!(" MAXSIZE {}", size).as_str());
         }
 
         command.push_str(
             format!(
                 ") {} ({})",
                 mailbox
-                    .map(|mbox| validate_str(mbox.as_ref()).unwrap())
+                    .map(|mbox| validate_str(mbox).unwrap())
                     .unwrap_or_else(|| "\"\"".to_string()),
                 s
             )

--- a/src/extensions/metadata.rs
+++ b/src/extensions/metadata.rs
@@ -12,7 +12,7 @@
 
 use crate::client::*;
 use crate::error::{Error, ParseError, Result};
-use crate::parse::handle_unilateral;
+use crate::parse::try_handle_unilateral;
 use crate::types::*;
 use imap_proto::types::{MailboxDatum, Metadata, Response, ResponseCode};
 use std::io::{Read, Write};
@@ -97,7 +97,7 @@ fn parse_metadata<'a>(
                         res.append(&mut values);
                     }
                     _ => {
-                        if let Some(unhandled) = handle_unilateral(resp, unsolicited) {
+                        if let Some(unhandled) = try_handle_unilateral(resp, unsolicited) {
                             break Err(unhandled.into());
                         }
                     }


### PR DESCRIPTION
While working on handling unsolicited responses in the other branch, bumped into these:

- Rename `handle_unilateral` to `try_handle_unilateral` because [suggested here](https://github.com/jonhoo/rust-imap/pull/130#discussion_r316369815).
- Make clippy happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/184)
<!-- Reviewable:end -->
