### PR TITLE
Support parsing STATUS responses.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1064,12 +1064,15 @@ impl<T: Read + Write> Session<T> {
         mailbox_name: S1,
         data_items: S2,
     ) -> Result<Mailbox> {
+        let mailbox_name = mailbox_name.as_ref();
         self.run_command_and_read_response(&format!(
             "STATUS {} {}",
-            validate_str(mailbox_name.as_ref())?,
+            validate_str(mailbox_name)?,
             data_items.as_ref()
         ))
-        .and_then(|lines| parse_mailbox(&lines[..], &mut self.unsolicited_responses_tx))
+        .and_then(|lines| {
+            parse_status(&lines[..], mailbox_name, &mut self.unsolicited_responses_tx)
+        })
     }
 
     /// This method returns a handle that lets you use the [`IDLE`

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,9 @@ pub enum Error {
     /// or an unsolicited response that could not be converted into a local type in
     /// [`UnsolicitedResponse`](crate::types::UnsolicitedResponse).
     Unexpected(Response<'static>),
+    /// In response to a STATUS command, the server sent OK without actually sending any STATUS
+    /// responses first.
+    MissingStatusResponse,
 }
 
 impl From<IoError> for Error {
@@ -148,6 +151,7 @@ impl fmt::Display for Error {
             Error::ConnectionLost => f.write_str("Connection Lost"),
             Error::Append => f.write_str("Could not append mail to mailbox"),
             Error::Unexpected(ref r) => write!(f, "Unexpected Response: {:?}", r),
+            Error::MissingStatusResponse => write!(f, "Missing STATUS Response"),
         }
     }
 }
@@ -170,6 +174,7 @@ impl StdError for Error {
             Error::ConnectionLost => "Connection lost",
             Error::Append => "Could not append mail to mailbox",
             Error::Unexpected(_) => "Unexpected Response",
+            Error::MissingStatusResponse => "Missing STATUS Response",
         }
     }
 


### PR DESCRIPTION
Fixes #185.

My use of ParseError::Unexpected for error messages feels a bit sketchy,
but I wasn't sure how you'd prefer to handle them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/192)
<!-- Reviewable:end -->
