### PR TITLE
3.0.0-alpha.3: missing 'std' feature for 'chrono'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bufstream = "0.1"
 imap-proto = "0.14.1"
 nom = { version = "6.0", default-features = false }
 base64 = "0.13"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["std"]}
 lazy_static = "1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Hi,

Since the commit 514735e9204ca7cc6e307d43c08d7827bea4bd6d which remove the "default features" for the dependency 'chrono', I now have this error : 

```
imap-3.0.0-alpha.3/src/client.rs:202:37
    format!(" \"{}\"", date.format("%d-%h-%Y %T %z"))
                              ^^^^ method not found in `DateTime<FixedOffset>>` 
```

So I think we have to add back the 'std' feature to 'chrono'
```
chrono = {version = "0.4", default-features = false, features = ["std"]}
```

(I know that I could add this dependency to my project Cargo.toml (and I did), but I think this should be in rust-imap)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/195)
<!-- Reviewable:end -->
