### PR TITLE
Add ClientBuilder helper to make setting up TLS connections easy.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,12 +11,12 @@ task:
     - . $HOME/.cargo/env
   check_script:
     - . $HOME/.cargo/env
-    - cargo check --all-targets
+    - cargo check --all-targets --all-features
   build_script:
     - . $HOME/.cargo/env
-    - cargo build --all-targets --verbose
+    - cargo build --all-targets --verbose --all-features
   test_script:
     - . $HOME/.cargo/env
-    - cargo test --examples
-    - cargo test --doc
-    - cargo test --lib
+    - cargo test --examples --all-features
+    - cargo test --doc --all-features
+    - cargo test --lib --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,14 @@ required-features = ["default"]
 name = "idle"
 required-features = ["default"]
 
+[[example]]
+name = "starttls"
+required-features = ["default"]
+
+[[example]]
+name = "timeout"
+required-features = ["default"]
+
 [[test]]
 name = "imap_integration"
 required-features = ["default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ name = "idle"
 required-features = ["default"]
 
 [[example]]
+name = "rustls"
+required-features = ["rustls-tls"]
+
+[[example]]
 name = "starttls"
 required-features = ["default"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ categories = ["email", "network-programming"]
 
 [features]
 tls = ["native-tls"]
+rustls-tls = ["rustls-connector"]
 default = ["tls"]
 
 [dependencies]
 native-tls = { version = "0.2.2", optional = true }
+rustls-connector = { version = "0.13.1", optional = true }
 regex = "1.0"
 bufstream = "0.1"
 imap-proto = "0.14.1"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ results](https://dev.azure.com/jonhoo/jonhoo/_build/latest?definitionId=11&branc
 
 [@jonhoo]: https://thesquareplanet.com/
 
-To connect, use the [`connect`] function. This gives you an unauthenticated [`Client`]. You can
+To connect, use the [`ClientBuilder`]. This gives you an unauthenticated [`Client`]. You can
 then use [`Client::login`] or [`Client::authenticate`] to perform username/password or
 challenge/response authentication respectively. This in turn gives you an authenticated
 [`Session`], which lets you access the mailboxes at the server.
@@ -34,16 +34,9 @@ in the documentation for the various types and methods and read the raw text the
 Below is a basic client example. See the `examples/` directory for more.
 
 ```rust
-extern crate imap;
-extern crate native_tls;
-
 fn fetch_inbox_top() -> imap::error::Result<Option<String>> {
-    let domain = "imap.example.com";
-    let tls = native_tls::TlsConnector::builder().build().unwrap();
 
-    // we pass in the domain twice to check that the server's TLS
-    // certificate is valid for the domain we're connecting to.
-    let client = imap::connect((domain, 993), domain, &tls).unwrap();
+    let client = imap::ClientBuilder::new("imap.example.com", 993).native_tls()?;
 
     // the client we have here is unauthenticated.
     // to do anything useful with the e-mails, we need to log in
@@ -90,7 +83,8 @@ default-features = false
 ```
 
 Even without `native_tls`, you can still use TLS by leveraging the pure Rust `rustls`
-crate. See the example/rustls.rs file for a working example.
+crate, which is enabled with the `rustls-tls` feature. See the example/rustls.rs file
+for a working example.
 
 ## Running the test suite
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,18 @@ jobs:
        greenmail: greenmail
      env:
        TEST_HOST: greenmail
+ - job: features
+   displayName: "Check feature combinations"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+       parameters:
+         rust: stable
+     - script: cargo install cargo-hack
+       displayName: install cargo-hack
+     - script: cargo hack --feature-powerset check --all-targets
+       displayName: cargo hack
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,13 +25,13 @@ jobs:
      - template: install-rust.yml@templates
        parameters:
          rust: $(rust)
-     - script: cargo check --all-targets
+     - script: cargo check --all-targets --all-features
        displayName: cargo check
-     - script: cargo test --examples
+     - script: cargo test --examples --all-features
        displayName: cargo test --examples
-     - script: cargo test --doc
+     - script: cargo test --doc --all-features
        displayName: cargo test --doc
-     - script: cargo test --lib
+     - script: cargo test --lib --all-features
        displayName: cargo test --lib
      - script: |
          set -e

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  range: 70..100
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        threshold: 2%
+
+# Tests aren't important for coverage
+ignore:
+  - "tests"
+
+# Make less noisy comments
+comment:
+  layout: "files"
+  require_changes: yes

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,5 +6,7 @@ This directory contains examples of working with the IMAP client.
 Examples:
   * basic - This is a very basic example of using the client.
   * gmail_oauth2 - This is an example using oauth2 for logging into gmail as a secure appplication.
+  * idle - This is an example showing how to use IDLE to monitor a mailbox.
   * rustls - This demonstrates how to use Rustls instead of Openssl for secure connections (helpful for cross compilation).
-  * timeout - This demonstrates how to use timeouts while connecting to an IMAP server.
+  * starttls - This is an example showing how to use STARTTLS after connecting over plaintext.
+  * timeout - This demonstrates how to use timeouts while connecting to an IMAP server by using a custom TCP/TLS stream initialization and creating a `Client` directly instead of using the `ClientBuilder`.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,4 @@
 extern crate imap;
-extern crate native_tls;
 
 fn main() {
     // To connect to the gmail IMAP server with this you will need to allow unsecure apps access.
@@ -9,12 +8,7 @@ fn main() {
 }
 
 fn fetch_inbox_top() -> imap::error::Result<Option<String>> {
-    let domain = "imap.example.com";
-    let tls = native_tls::TlsConnector::builder().build().unwrap();
-
-    // we pass in the domain twice to check that the server's TLS
-    // certificate is valid for the domain we're connecting to.
-    let client = imap::connect((domain, 993), domain, &tls).unwrap();
+    let client = imap::ClientBuilder::new("imap.example.com", 993).native_tls()?;
 
     // the client we have here is unauthenticated.
     // to do anything useful with the e-mails, we need to log in

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -1,8 +1,5 @@
 extern crate base64;
 extern crate imap;
-extern crate native_tls;
-
-use native_tls::TlsConnector;
 
 struct GmailOAuth2 {
     user: String,
@@ -25,11 +22,10 @@ fn main() {
         user: String::from("sombody@gmail.com"),
         access_token: String::from("<access_token>"),
     };
-    let domain = "imap.gmail.com";
-    let port = 993;
-    let socket_addr = (domain, port);
-    let ssl_connector = TlsConnector::builder().build().unwrap();
-    let client = imap::connect(socket_addr, domain, &ssl_connector).unwrap();
+
+    let client = imap::ClientBuilder::new("imap.gmail.com", 993)
+        .native_tls()
+        .expect("Could not connect to imap.gmail.com");
 
     let mut imap_session = match client.authenticate("XOAUTH2", &gmail_auth) {
         Ok(c) => c,

--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -1,4 +1,3 @@
-use native_tls::TlsConnector;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -39,9 +38,10 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
 
-    let ssl_conn = TlsConnector::builder().build().unwrap();
-    let client = imap::connect((opt.server.clone(), opt.port), opt.server, &ssl_conn)
+    let client = imap::ClientBuilder::new(opt.server.clone(), opt.port)
+        .native_tls()
         .expect("Could not connect to imap server");
+
     let mut imap = client
         .login(opt.username, opt.password)
         .expect("Could not authenticate");

--- a/examples/rustls.rs
+++ b/examples/rustls.rs
@@ -1,9 +1,6 @@
 extern crate imap;
-extern crate rustls_connector;
 
-use std::{env, error::Error, net::TcpStream};
-
-use rustls_connector::RustlsConnector;
+use std::{env, error::Error};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Read config from environment or .env file
@@ -25,14 +22,7 @@ fn fetch_inbox_top(
     password: String,
     port: u16,
 ) -> Result<Option<String>, Box<dyn Error>> {
-    // Setup Rustls TcpStream
-    let stream = TcpStream::connect((host.as_ref(), port))?;
-    let tls = RustlsConnector::default();
-    let tlsstream = tls.connect(&host, stream)?;
-
-    // we pass in the domain twice to check that the server's TLS
-    // certificate is valid for the domain we're connecting to.
-    let client = imap::Client::new(tlsstream);
+    let client = imap::ClientBuilder::new(&host, port).rustls()?;
 
     // the client we have here is unauthenticated.
     // to do anything useful with the e-mails, we need to log in

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -58,8 +58,7 @@ fn connect_timeout<S: AsRef<str>>(
     Ok(client)
 }
 
-// resolve address and try to connect to all in order; note that this function is required to fully
-// mimic `imap::connect` with the usage of `ToSocketAddrs`
+// resolve address and try to connect to all in order
 fn connect_all_timeout<A: ToSocketAddrs, S: AsRef<str>>(
     addr: A,
     domain: S,

--- a/src/client.rs
+++ b/src/client.rs
@@ -414,6 +414,14 @@ impl<T: Read + Write> Client<T> {
         }
     }
 
+    /// Yield the underlying connection for this Client.
+    /// This consumes `self` since the Client is not much use without
+    /// an underlying transport.
+    pub(crate) fn into_inner(self) -> Result<T> {
+        let res = self.conn.stream.into_inner()?;
+        Ok(res)
+    }
+
     /// Log in to the IMAP server. Upon success a [`Session`](struct.Session.html) instance is
     /// returned; on error the original `Client` instance is returned in addition to the error.
     /// This is because `login` takes ownership of `self`, so in order to try again (e.g. after
@@ -1379,7 +1387,7 @@ impl<T: Read + Write> Connection<T> {
         Ok(v)
     }
 
-    fn run_command_and_check_ok(&mut self, command: &str) -> Result<()> {
+    pub(crate) fn run_command_and_check_ok(&mut self, command: &str) -> Result<()> {
         self.run_command_and_read_response(command).map(|_| ())
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -384,20 +384,18 @@ impl<T: Read + Write> Client<T> {
     /// # use imap::Client;
     /// # use std::io;
     /// # use std::net::TcpStream;
+    /// # {} #[cfg(feature = "tls")]
     /// # fn main() {
     /// # let server = "imap.example.com";
     /// # let username = "";
     /// # let password = "";
     /// # let tcp = TcpStream::connect((server, 993)).unwrap();
-    /// # #[cfg(feature = "tls")]
-    /// # {
     /// # use native_tls::TlsConnector;
     /// # let ssl_connector = TlsConnector::builder().build().unwrap();
     /// # let tls = TlsConnector::connect(&ssl_connector, server.as_ref(), tcp).unwrap();
     /// let mut client = Client::new(tls);
     /// client.read_greeting().unwrap();
     /// let session = client.login(username, password).unwrap();
-    /// # }
     /// # }
     /// ```
     pub fn new(stream: T) -> Client<T> {
@@ -427,9 +425,8 @@ impl<T: Read + Write> Client<T> {
     /// transferred back to the caller.
     ///
     /// ```rust,no_run
+    /// # {} #[cfg(feature = "tls")]
     /// # fn main() {
-    /// # #[cfg(feature = "tls")]
-    /// # {
     /// # use native_tls::TlsConnector;
     /// # let tls_connector = TlsConnector::builder().build().unwrap();
     /// let client = imap::connect(
@@ -446,7 +443,6 @@ impl<T: Read + Write> Client<T> {
     ///         // prompt user and try again with orig_client here
     ///         return;
     ///     }
-    /// # }
     /// }
     /// # }
     /// ```
@@ -487,14 +483,13 @@ impl<T: Read + Write> Client<T> {
     ///     }
     /// }
     ///
+    /// # {} #[cfg(feature = "tls")]
     /// fn main() {
     ///     let auth = OAuth2 {
     ///         user: String::from("me@example.com"),
     ///         access_token: String::from("<access_token>"),
     ///     };
     ///     let domain = "imap.example.com";
-    /// # #[cfg(feature = "tls")]
-    /// # {
     ///     let tls = TlsConnector::builder().build().unwrap();
     ///     let client = imap::connect((domain, 993), domain, &tls).unwrap();
     ///     match client.authenticate("XOAUTH2", &auth) {
@@ -507,7 +502,6 @@ impl<T: Read + Write> Client<T> {
     ///             return;
     ///         }
     ///     };
-    /// # }
     /// }
     /// ```
     pub fn authenticate<A: Authenticator, S: AsRef<str>>(

--- a/src/client.rs
+++ b/src/client.rs
@@ -415,6 +415,7 @@ impl<T: Read + Write> Client<T> {
     }
 
     /// Yield the underlying connection for this Client.
+    ///
     /// This consumes `self` since the Client is not much use without
     /// an underlying transport.
     pub(crate) fn into_inner(self) -> Result<T> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -264,8 +264,6 @@ impl<T: Read + Write> DerefMut for Session<T> {
 /// # Examples
 ///
 /// ```no_run
-/// # extern crate native_tls;
-/// # extern crate imap;
 /// # use std::io;
 /// # use native_tls::TlsConnector;
 /// # fn main() {
@@ -302,8 +300,6 @@ pub fn connect<A: ToSocketAddrs, S: AsRef<str>>(
 /// # Examples
 ///
 /// ```no_run
-/// # extern crate native_tls;
-/// # extern crate imap;
 /// # use std::io;
 /// # use native_tls::TlsConnector;
 /// # fn main() {
@@ -385,10 +381,7 @@ impl<T: Read + Write> Client<T> {
     /// listen for the IMAP protocol server greeting before authenticating:
     ///
     /// ```rust,no_run
-    /// # extern crate imap;
-    /// # extern crate native_tls;
     /// # use imap::Client;
-    /// # use native_tls::TlsConnector;
     /// # use std::io;
     /// # use std::net::TcpStream;
     /// # fn main() {
@@ -396,11 +389,15 @@ impl<T: Read + Write> Client<T> {
     /// # let username = "";
     /// # let password = "";
     /// # let tcp = TcpStream::connect((server, 993)).unwrap();
+    /// # #[cfg(feature = "tls")]
+    /// # {
+    /// # use native_tls::TlsConnector;
     /// # let ssl_connector = TlsConnector::builder().build().unwrap();
     /// # let tls = TlsConnector::connect(&ssl_connector, server.as_ref(), tcp).unwrap();
     /// let mut client = Client::new(tls);
     /// client.read_greeting().unwrap();
     /// let session = client.login(username, password).unwrap();
+    /// # }
     /// # }
     /// ```
     pub fn new(stream: T) -> Client<T> {
@@ -430,11 +427,10 @@ impl<T: Read + Write> Client<T> {
     /// transferred back to the caller.
     ///
     /// ```rust,no_run
-    /// # extern crate imap;
-    /// # extern crate native_tls;
-    /// # use std::io;
-    /// # use native_tls::TlsConnector;
     /// # fn main() {
+    /// # #[cfg(feature = "tls")]
+    /// # {
+    /// # use native_tls::TlsConnector;
     /// # let tls_connector = TlsConnector::builder().build().unwrap();
     /// let client = imap::connect(
     ///     ("imap.example.org", 993),
@@ -450,6 +446,7 @@ impl<T: Read + Write> Client<T> {
     ///         // prompt user and try again with orig_client here
     ///         return;
     ///     }
+    /// # }
     /// }
     /// # }
     /// ```
@@ -472,8 +469,7 @@ impl<T: Read + Write> Client<T> {
     /// challenge.
     ///
     /// ```no_run
-    /// extern crate imap;
-    /// extern crate native_tls;
+    /// # #[cfg(feature = "tls")]
     /// use native_tls::TlsConnector;
     ///
     /// struct OAuth2 {
@@ -497,6 +493,8 @@ impl<T: Read + Write> Client<T> {
     ///         access_token: String::from("<access_token>"),
     ///     };
     ///     let domain = "imap.example.com";
+    /// # #[cfg(feature = "tls")]
+    /// # {
     ///     let tls = TlsConnector::builder().build().unwrap();
     ///     let client = imap::connect((domain, 993), domain, &tls).unwrap();
     ///     match client.authenticate("XOAUTH2", &auth) {
@@ -509,6 +507,7 @@ impl<T: Read + Write> Client<T> {
     ///             return;
     ///         }
     ///     };
+    /// # }
     /// }
     /// ```
     pub fn authenticate<A: Authenticator, S: AsRef<str>>(

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -12,8 +12,8 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// Creating a [`Client`] using `native-tls` transport is straightforward:
 /// ```no_run
 /// # use imap::ClientBuilder;
+/// # {} #[cfg(feature = "tls")]
 /// # fn main() -> Result<(), imap::Error> {
-/// # #[cfg(feature = "tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993).native_tls()?;
 /// # Ok(())
 /// # }
@@ -22,8 +22,8 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// Similarly, if using the `rustls-tls` feature you can create a [`Client`] using rustls:
 /// ```no_run
 /// # use imap::ClientBuilder;
+/// # {} #[cfg(feature = "rustls-tls")]
 /// # fn main() -> Result<(), imap::Error> {
-/// # #[cfg(feature = "rustls-tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993).rustls()?;
 /// # Ok(())
 /// # }
@@ -33,8 +33,8 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// functions:
 /// ```no_run
 /// # use imap::ClientBuilder;
+/// # {} #[cfg(feature = "rustls-tls")]
 /// # fn main() -> Result<(), imap::Error> {
-/// # #[cfg(feature = "rustls-tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993)
 ///     .starttls()
 ///     .rustls()?;
@@ -110,8 +110,8 @@ where
     /// ```no_run
     /// # use imap::ClientBuilder;
     /// # use rustls_connector::RustlsConnector;
+    /// # {} #[cfg(feature = "rustls-tls")]
     /// # fn main() -> Result<(), imap::Error> {
-    /// # #[cfg(feature = "rustls-tls")]
     /// let client = ClientBuilder::new("imap.example.com", 993)
     ///     .starttls()
     ///     .connect(|domain, tcp| {

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -41,6 +41,8 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// # Ok(())
 /// # }
 /// ```
+/// The returned [`Client`] is unauthenticated; to access session-related methods (through
+/// [`Session`](crate::Session)), use [`Client::login`] or [`Client::authenticate`].
 pub struct ClientBuilder<D>
 where
     D: AsRef<str>,
@@ -63,7 +65,7 @@ where
         }
     }
 
-    /// Use `STARTTLS` for this connection.
+    /// Use [`STARTTLS`](https://tools.ietf.org/html/rfc2595) for this connection.
     #[cfg(any(feature = "tls", feature = "rustls-tls"))]
     pub fn starttls(&mut self) -> &mut Self {
         self.starttls = true;

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -1,7 +1,7 @@
 use crate::{Client, Result};
 use std::net::TcpStream;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "tls")]
 use native_tls::{TlsConnector, TlsStream};
 #[cfg(feature = "rustls-tls")]
 use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
@@ -60,15 +60,15 @@ where
     }
 
     /// Use `STARTTLS` for this connection.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg(any(feature = "tls", feature = "rustls-tls"))]
     pub fn starttls(&mut self) -> &mut Self {
         self.starttls = true;
         self
     }
 
     /// Return a new [`Client`] using a `native-tls` transport.
-    #[cfg(feature = "native-tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub fn native_tls(&mut self) -> Result<Client<TlsStream<TcpStream>>> {
         let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
         if self.starttls {

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -1,0 +1,108 @@
+use crate::{Client, Result};
+use std::net::TcpStream;
+
+#[cfg(feature = "native-tls")]
+use native_tls::{TlsConnector, TlsStream};
+#[cfg(feature = "rustls-tls")]
+use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
+
+/// A convenience builder for [`Client`] structs over various encrypted transports.
+///
+/// Creating a [`Client`] using `native-tls` transport is straightforward:
+/// ```no_run
+/// # use imap::ClientBuilder;
+/// # fn main() -> Result<(), imap::Error> {
+/// let client = ClientBuilder::new("imap.example.com", 993).native_tls()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Similarly, if using the `rustls-tls` feature you can create a [`Client`] using rustls:
+/// ```no_run
+/// # use imap::ClientBuilder;
+/// # fn main() -> Result<(), imap::Error> {
+/// let client = ClientBuilder::new("imap.example.com", 993).rustls()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// To use `STARTTLS`, just call `starttls()` before one of the [`Client`]-yielding
+/// functions:
+/// ```no_run
+/// # use imap::ClientBuilder;
+/// # fn main() -> Result<(), imap::Error> {
+/// let client = ClientBuilder::new("imap.example.com", 993)
+///     .starttls()
+///     .rustls()?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct ClientBuilder<D>
+where
+    D: AsRef<str>,
+{
+    domain: D,
+    port: u16,
+    starttls: bool,
+}
+
+impl<D> ClientBuilder<D>
+where
+    D: AsRef<str>,
+{
+    /// Make a new `ClientBuilder` using the given domain and port.
+    pub fn new(domain: D, port: u16) -> Self {
+        ClientBuilder {
+            domain,
+            port,
+            starttls: false,
+        }
+    }
+
+    /// Use `STARTTLS` for this connection.
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    pub fn starttls(&mut self) -> &mut Self {
+        self.starttls = true;
+        self
+    }
+
+    /// Return a new [`Client`] using a `native-tls` transport.
+    #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+    pub fn native_tls(&mut self) -> Result<Client<TlsStream<TcpStream>>> {
+        if self.starttls {
+            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
+            let mut client = Client::new(tcp);
+            client.read_greeting()?;
+            client.run_command_and_check_ok("STARTTLS")?;
+            let ssl_conn = TlsConnector::builder().build()?;
+            let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), client.into_inner()?)?;
+            Ok(Client::new(tls))
+        } else {
+            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
+            let ssl_conn = TlsConnector::builder().build()?;
+            let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), tcp)?;
+            Ok(Client::new(tls))
+        }
+    }
+
+    /// Return a new [`Client`] using `rustls` transport.
+    #[cfg(feature = "rustls-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn rustls(&mut self) -> Result<Client<RustlsStream<TcpStream>>> {
+        if self.starttls {
+            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
+            let mut client = Client::new(tcp);
+            client.read_greeting()?;
+            client.run_command_and_check_ok("STARTTLS")?;
+            let ssl_conn = RustlsConnector::new_with_native_certs()?;
+            let tls = ssl_conn.connect(self.domain.as_ref(), client.into_inner()?)?;
+            Ok(Client::new(tls))
+        } else {
+            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
+            let ssl_conn = RustlsConnector::new_with_native_certs()?;
+            let tls = ssl_conn.connect(self.domain.as_ref(), tcp)?;
+            Ok(Client::new(tls))
+        }
+    }
+}

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -1,4 +1,5 @@
 use crate::{Client, Result};
+use std::io::{Read, Write};
 use std::net::TcpStream;
 
 #[cfg(feature = "tls")]
@@ -70,37 +71,68 @@ where
     #[cfg(feature = "tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub fn native_tls(&mut self) -> Result<Client<TlsStream<TcpStream>>> {
-        let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
-        if self.starttls {
-            let mut client = Client::new(tcp);
-            client.read_greeting()?;
-            client.run_command_and_check_ok("STARTTLS")?;
+        self.connect(|domain, tcp| {
             let ssl_conn = TlsConnector::builder().build()?;
-            let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), client.into_inner()?)?;
-            Ok(Client::new(tls))
-        } else {
-            let ssl_conn = TlsConnector::builder().build()?;
-            let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), tcp)?;
-            Ok(Client::new(tls))
-        }
+            Ok(TlsConnector::connect(&ssl_conn, domain, tcp)?)
+        })
     }
 
     /// Return a new [`Client`] using `rustls` transport.
     #[cfg(feature = "rustls-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn rustls(&mut self) -> Result<Client<RustlsStream<TcpStream>>> {
-        let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
-        if self.starttls {
+        self.connect(|domain, tcp| {
+            let ssl_conn = RustlsConnector::new_with_native_certs()?;
+            Ok(ssl_conn.connect(domain, tcp)?)
+        })
+    }
+
+    /// Make a [`Client`] using a custom TLS initialization. This function is intended
+    /// to be used if your TLS setup requires custom work such as adding private CAs
+    /// or other specific TLS parameters.
+    ///
+    /// The `handshake` argument should accept two parameters:
+    ///
+    /// - domain: [`&str`]
+    /// - tcp: [`TcpStream`]
+    ///
+    /// and yield a `Result<C>` where `C` is `Read + Write`. It should only perform
+    /// TLS initialization over the given `tcp` socket and return the encrypted stream
+    /// object, such as a [`native_tls::TlsStream`] or a [`rustls_connector::TlsStream`].
+    ///
+    /// If the caller is using `STARTTLS` and previously called [`starttls`](Self::starttls)
+    /// then the `tcp` socket given to the `handshake` function will be connected and will
+    /// have initiated the `STARTTLS` handshake.
+    ///
+    /// ```no_run
+    /// # use imap::ClientBuilder;
+    /// # use rustls_connector::RustlsConnector;
+    /// # fn main() -> Result<(), imap::Error> {
+    /// let client = ClientBuilder::new("imap.example.com", 993)
+    ///     .starttls()
+    ///     .connect(|domain, tcp| {
+    ///         let ssl_conn = RustlsConnector::new_with_native_certs()?;
+    ///         Ok(ssl_conn.connect(domain, tcp)?)
+    ///     })?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn connect<F, C>(&mut self, handshake: F) -> Result<Client<C>>
+    where
+        F: FnOnce(&str, TcpStream) -> Result<C>,
+        C: Read + Write,
+    {
+        let tcp = if self.starttls {
+            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
             let mut client = Client::new(tcp);
             client.read_greeting()?;
             client.run_command_and_check_ok("STARTTLS")?;
-            let ssl_conn = RustlsConnector::new_with_native_certs()?;
-            let tls = ssl_conn.connect(self.domain.as_ref(), client.into_inner()?)?;
-            Ok(Client::new(tls))
+            client.into_inner()?
         } else {
-            let ssl_conn = RustlsConnector::new_with_native_certs()?;
-            let tls = ssl_conn.connect(self.domain.as_ref(), tcp)?;
-            Ok(Client::new(tls))
-        }
+            TcpStream::connect((self.domain.as_ref(), self.port))?
+        };
+
+        let tls = handshake(self.domain.as_ref(), tcp)?;
+        Ok(Client::new(tls))
     }
 }

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -13,6 +13,7 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// ```no_run
 /// # use imap::ClientBuilder;
 /// # fn main() -> Result<(), imap::Error> {
+/// # #[cfg(feature = "tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993).native_tls()?;
 /// # Ok(())
 /// # }
@@ -22,6 +23,7 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// ```no_run
 /// # use imap::ClientBuilder;
 /// # fn main() -> Result<(), imap::Error> {
+/// # #[cfg(feature = "rustls-tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993).rustls()?;
 /// # Ok(())
 /// # }
@@ -32,6 +34,7 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// ```no_run
 /// # use imap::ClientBuilder;
 /// # fn main() -> Result<(), imap::Error> {
+/// # #[cfg(feature = "rustls-tls")]
 /// let client = ClientBuilder::new("imap.example.com", 993)
 ///     .starttls()
 ///     .rustls()?;
@@ -108,6 +111,7 @@ where
     /// # use imap::ClientBuilder;
     /// # use rustls_connector::RustlsConnector;
     /// # fn main() -> Result<(), imap::Error> {
+    /// # #[cfg(feature = "rustls-tls")]
     /// let client = ClientBuilder::new("imap.example.com", 993)
     ///     .starttls()
     ///     .connect(|domain, tcp| {

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -70,8 +70,8 @@ where
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn native_tls(&mut self) -> Result<Client<TlsStream<TcpStream>>> {
+        let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
         if self.starttls {
-            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
             let mut client = Client::new(tcp);
             client.read_greeting()?;
             client.run_command_and_check_ok("STARTTLS")?;
@@ -79,7 +79,6 @@ where
             let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), client.into_inner()?)?;
             Ok(Client::new(tls))
         } else {
-            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
             let ssl_conn = TlsConnector::builder().build()?;
             let tls = TlsConnector::connect(&ssl_conn, self.domain.as_ref(), tcp)?;
             Ok(Client::new(tls))
@@ -90,8 +89,8 @@ where
     #[cfg(feature = "rustls-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn rustls(&mut self) -> Result<Client<RustlsStream<TcpStream>>> {
+        let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
         if self.starttls {
-            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
             let mut client = Client::new(tcp);
             client.read_greeting()?;
             client.run_command_and_check_ok("STARTTLS")?;
@@ -99,7 +98,6 @@ where
             let tls = ssl_conn.connect(self.domain.as_ref(), client.into_inner()?)?;
             Ok(Client::new(tls))
         } else {
-            let tcp = TcpStream::connect((self.domain.as_ref(), self.port))?;
             let ssl_conn = RustlsConnector::new_with_native_certs()?;
             let tls = ssl_conn.connect(self.domain.as_ref(), tcp)?;
             Ok(Client::new(tls))

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IoError;
-#[cfg(feature = "tls")]
 use std::net::TcpStream;
 use std::result;
 use std::str::Utf8Error;

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -30,9 +30,7 @@ use std::time::Duration;
 /// use imap::extensions::idle;
 /// # #[cfg(feature = "tls")]
 /// # {
-/// # use native_tls::TlsConnector;
-/// let ssl_conn = TlsConnector::builder().build().unwrap();
-/// let client = imap::connect(("example.com", 993), "example.com", &ssl_conn)
+/// let client = imap::ClientBuilder::new("example.com", 993).native_tls()
 ///     .expect("Could not connect to imap server");
 /// let mut imap = client.login("user@example.com", "password")
 ///     .expect("Could not authenticate");

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -27,8 +27,10 @@ use std::time::Duration;
 /// a convenience callback function [`stop_on_any`] is provided.
 ///
 /// ```no_run
-/// # use native_tls::TlsConnector;
 /// use imap::extensions::idle;
+/// # #[cfg(feature = "tls")]
+/// # {
+/// # use native_tls::TlsConnector;
 /// let ssl_conn = TlsConnector::builder().build().unwrap();
 /// let client = imap::connect(("example.com", 993), "example.com", &ssl_conn)
 ///     .expect("Could not connect to imap server");
@@ -41,6 +43,7 @@ use std::time::Duration;
 ///
 /// // Exit on any mailbox change
 /// let result = idle.wait_keepalive_while(idle::stop_on_any);
+/// # }
 /// ```
 ///
 /// Note that the server MAY consider a client inactive if it has an IDLE command running, and if

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -7,6 +7,8 @@ use crate::parse::parse_idle;
 use crate::types::UnsolicitedResponse;
 #[cfg(feature = "tls")]
 use native_tls::TlsStream;
+#[cfg(feature = "rustls-tls")]
+use rustls_connector::TlsStream as RustlsStream;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::time::Duration;
@@ -280,6 +282,13 @@ impl<'a> SetReadTimeout for TcpStream {
 
 #[cfg(feature = "tls")]
 impl<'a> SetReadTimeout for TlsStream<TcpStream> {
+    fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<()> {
+        self.get_ref().set_read_timeout(timeout).map_err(Error::Io)
+    }
+}
+
+#[cfg(feature = "rustls-tls")]
+impl<'a> SetReadTimeout for RustlsStream<TcpStream> {
     fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<()> {
         self.get_ref().set_read_timeout(timeout).map_err(Error::Io)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,7 @@
 //! Below is a basic client example. See the `examples/` directory for more.
 //!
 //! ```no_run
-//! extern crate imap;
-//! extern crate native_tls;
-//!
+//! # #[cfg(feature = "tls")]
 //! fn fetch_inbox_top() -> imap::error::Result<Option<String>> {
 //!     let domain = "imap.example.com";
 //!     let tls = native_tls::TlsConnector::builder().build().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ pub use crate::authenticator::Authenticator;
 
 mod client;
 pub use crate::client::*;
+mod client_builder;
+pub use crate::client_builder::ClientBuilder;
 
 pub mod error;
 pub use error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! [@jonhoo]: https://thesquareplanet.com/
 //!
-//! To connect, use the [`connect`] function. This gives you an unauthenticated [`Client`]. You can
+//! To connect, use the [`ClientBuilder`]. This gives you an unauthenticated [`Client`]. You can
 //! then use [`Client::login`] or [`Client::authenticate`] to perform username/password or
 //! challenge/response authentication respectively. This in turn gives you an authenticated
 //! [`Session`], which lets you access the mailboxes at the server.
@@ -23,12 +23,8 @@
 //! ```no_run
 //! # #[cfg(feature = "tls")]
 //! fn fetch_inbox_top() -> imap::error::Result<Option<String>> {
-//!     let domain = "imap.example.com";
-//!     let tls = native_tls::TlsConnector::builder().build().unwrap();
 //!
-//!     // we pass in the domain twice to check that the server's TLS
-//!     // certificate is valid for the domain we're connecting to.
-//!     let client = imap::connect((domain, 993), domain, &tls).unwrap();
+//!     let client = imap::ClientBuilder::new("imap.example.com", 993).native_tls()?;
 //!
 //!     // the client we have here is unauthenticated.
 //!     // to do anything useful with the e-mails, we need to log in
@@ -75,7 +71,8 @@
 //! ```
 //!
 //! Even without `native_tls`, you can still use TLS by leveraging the pure Rust `rustls`
-//! crate. See the example/rustls.rs file for a working example.
+//! crate, which is enabled with the `rustls-tls` feature. See the example/rustls.rs file
+//! for a working example.
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -20,9 +20,8 @@ use std::ops::RangeInclusive;
 /// ```no_run
 /// # {} #[cfg(feature = "tls")]
 /// # fn main() {
-/// # let domain = "imap.example.com";
-/// # let tls = native_tls::TlsConnector::builder().build().unwrap();
-/// # let client = imap::connect((domain, 993), domain, &tls).unwrap();
+/// # let client = imap::ClientBuilder::new("imap.example.com", 993)
+///     .native_tls().unwrap();
 /// # let mut session = client.login("name", "pw").unwrap();
 /// // Iterate over whatever is returned
 /// if let Ok(deleted) = session.expunge() {

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -19,6 +19,8 @@ use std::ops::RangeInclusive;
 /// # Examples
 /// ```no_run
 /// # let domain = "imap.example.com";
+/// # #[cfg(feature = "tls")]
+/// # {
 /// # let tls = native_tls::TlsConnector::builder().build().unwrap();
 /// # let client = imap::connect((domain, 993), domain, &tls).unwrap();
 /// # let mut session = client.login("name", "pw").unwrap();
@@ -34,6 +36,7 @@ use std::ops::RangeInclusive;
 ///     for uid in deleted.uids() {
 ///         // Do something with uid
 ///     }
+/// # }
 /// }
 /// ```
 #[derive(Debug, Clone)]

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -18,9 +18,9 @@ use std::ops::RangeInclusive;
 ///
 /// # Examples
 /// ```no_run
+/// # {} #[cfg(feature = "tls")]
+/// # fn main() {
 /// # let domain = "imap.example.com";
-/// # #[cfg(feature = "tls")]
-/// # {
 /// # let tls = native_tls::TlsConnector::builder().build().unwrap();
 /// # let client = imap::connect((domain, 993), domain, &tls).unwrap();
 /// # let mut session = client.login("name", "pw").unwrap();
@@ -36,8 +36,8 @@ use std::ops::RangeInclusive;
 ///     for uid in deleted.uids() {
 ///         // Do something with uid
 ///     }
-/// # }
 /// }
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub enum Deleted {

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -19,17 +19,12 @@ fn tls() -> native_tls::TlsConnector {
 }
 
 fn session(user: &str) -> imap::Session<native_tls::TlsStream<TcpStream>> {
-    let mut s = imap::connect(
-        &format!(
-            "{}:3993",
-            std::env::var("TEST_HOST").unwrap_or("127.0.0.1".to_string())
-        ),
-        "imap.example.com",
-        &tls(),
-    )
-    .unwrap()
-    .login(user, user)
-    .unwrap();
+    let host = std::env::var("TEST_HOST").unwrap_or("127.0.0.1".to_string());
+    let mut s = imap::ClientBuilder::new(&host, 3993)
+        .native_tls()
+        .unwrap()
+        .login(user, user)
+        .unwrap();
     s.debug = true;
     s
 }
@@ -55,25 +50,17 @@ fn smtp(user: &str) -> lettre::SmtpTransport {
 #[ignore]
 fn connect_insecure_then_secure() {
     let host = std::env::var("TEST_HOST").unwrap_or("127.0.0.1".to_string());
-    let stream = TcpStream::connect((host.as_ref(), 3143)).unwrap();
-
     // ignored because of https://github.com/greenmail-mail-test/greenmail/issues/135
-    imap::Client::new(stream)
-        .secure("imap.example.com", &tls())
+    imap::ClientBuilder::new(&host, 3143)
+        .starttls()
+        .native_tls()
         .unwrap();
 }
 
 #[test]
 fn connect_secure() {
-    imap::connect(
-        &format!(
-            "{}:3993",
-            std::env::var("TEST_HOST").unwrap_or("127.0.0.1".to_string())
-        ),
-        "imap.example.com",
-        &tls(),
-    )
-    .unwrap();
+    let host = std::env::var("TEST_HOST").unwrap_or("127.0.0.1".to_string());
+    imap::ClientBuilder::new(&host, 3993).native_tls().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Addresses #190 

Also add support for rustls in addition to native-tls. I think using `rustls` should be easier (and could even be the default?), so I just made it first class like `native-tls`. I have tested both the `native_tls()` and `rustls()` paths.

This just adds the `ClientBuilder`. If we're happy with the API here and the way it works, then I can take care of:
- Fixing up the examples (doc and `/examples`) to use it where appropriate.
- If we want to get rid of any code that is superseded by this?

I have not tested the STARTTLS code, since I do not have a STARTTLS enabled server to work with. How do we want to handle automating the tests to make sure it all works?

I have not added it, but I can see an argument for adding some knobs to control which CA bundle is added, or adding private CAs or something. The alternative it to just leave the existing API as is, which allows users to make their own TLS connection using whatever configuration that they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/197)
<!-- Reviewable:end -->
