### PR TITLE
Fix doc warnings.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,7 +78,7 @@ pub enum Error {
     Append,
     /// An unexpected response was received. This could be a response from a command,
     /// or an unsolicited response that could not be converted into a local type in
-    /// [`UnsolicitedResponse`].
+    /// [`UnsolicitedResponse`](crate::types::UnsolicitedResponse).
     Unexpected(Response<'static>),
 }
 

--- a/src/extensions/sort.rs
+++ b/src/extensions/sort.rs
@@ -21,7 +21,8 @@ impl<'c> fmt::Display for SortCriteria<'c> {
     }
 }
 
-/// Message sorting preferences used for [`Session::sort`] and [`Session::uid_sort`].
+/// Message sorting preferences used for [`Session::sort`](crate::Session::sort)
+/// and [`Session::uid_sort`](crate::Session::uid_sort).
 ///
 /// Any sorting criterion that refers to an address (`From`, `To`, etc.) sorts according to the
 /// "addr-mailbox" of the indicated address. You can find the formal syntax for addr-mailbox [in


### PR DESCRIPTION
Fix some unresolved links when running `cargo doc`.