### PR TITLE
Update changelog for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - ???
-
-TODO
+## [Unreleased]
 
 ### Added
  - VANISHED support in EXPUNGE responses and unsolicited responses (#172).
+ - SORT command extension (#178).
 
 ### Changed
  - MSRV increased to 1.43 for nom6 and bitvec
  - `expunge` and `uid_expunge` return `Result<Deleted>` instead of `Result<Vec<u32>>`.
-
-### Removed
+ - Idle `wait_keepalive_while` replaces `wait_keepalive` and takes a callback with an `UnsolicitedResponse` in parameter.
+ - All `Session.append_with_*` methods are obsoleted by `append` which returns now an `AppendCmd` builder.
+ - Envelope `&'a [u8]` attributes are replaced by `Cow<'a, [u8]>`.
+ - `Flag` enum is now declared as non exhaustive.
 
 ## [2.4.1] - 2021-01-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - All `Session.append_with_*` methods are obsoleted by `append` which returns now an `AppendCmd` builder.
  - Envelope `&'a [u8]` attributes are replaced by `Cow<'a, [u8]>`.
  - `Flag` enum is now declared as non exhaustive.
+ - `ClientBuilder` now replaces the `imap::connect` function [#197](https://github.com/jonhoo/rust-imap/pull/197).
 
 ## [2.4.1] - 2021-01-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Idle `wait_keepalive_while` replaces `wait_keepalive` and takes a callback with an `UnsolicitedResponse` in parameter.
  - All `Session.append_with_*` methods are obsoleted by `append` which returns now an `AppendCmd` builder.
  - Envelope `&'a [u8]` attributes are replaced by `Cow<'a, [u8]>`.
- - `Flag` enum is now declared as non exhaustive.
+ - `Flag`, `Mailbox`, `UnsolicitedResponse` and `Error` are now declared as non exhaustive.
  - `ClientBuilder` now replaces the `imap::connect` function [#197](https://github.com/jonhoo/rust-imap/pull/197).
 
 ## [2.4.1] - 2021-01-12


### PR DESCRIPTION
I added breaking changes I noticed while integrating the `v3.0.0-alpha.3` in my tool: https://github.com/soywod/himalaya/commit/36d3cd63475ed63cd78c9328cc0fbed310b481f6. I also replaced the `v3.0.0 - ???` with `Unreleased`, let me know if it's okey.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/199)
<!-- Reviewable:end -->
