### PR TITLE
Idle builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - MSRV increased to 1.43 for nom6 and bitvec
  - `expunge` and `uid_expunge` return `Result<Deleted>` instead of `Result<Vec<u32>>`.
- - Idle `wait_keepalive_while` replaces `wait_keepalive` and takes a callback with an `UnsolicitedResponse` in parameter.
+ - IDLE capability now provides a builder interface. All `wait_*` functions are merged into `wait_while` which takes a callback with an `UnsolicitedResponse` in parameter.
  - All `Session.append_with_*` methods are obsoleted by `append` which returns now an `AppendCmd` builder.
  - Envelope `&'a [u8]` attributes are replaced by `Cow<'a, [u8]>`.
  - `Flag`, `Mailbox`, `UnsolicitedResponse` and `Error` are now declared as non exhaustive.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ keywords = ["email", "imap"]
 categories = ["email", "network-programming"]
 
 [features]
-tls = ["native-tls"]
 rustls-tls = ["rustls-connector"]
-default = ["tls"]
+default = ["native-tls"]
 
 [dependencies]
 native-tls = { version = "0.2.2", optional = true }

--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -74,7 +74,7 @@ fn main() {
     });
 
     match idle_result {
-        Ok(()) => println!("IDLE finished normally"),
+        Ok(reason) => println!("IDLE finished normally {:?}", reason),
         Err(e) => println!("IDLE finished with error {:?}", e),
     }
 

--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -54,8 +54,6 @@ fn main() {
 
     imap.select(opt.mailbox).expect("Could not select mailbox");
 
-    let idle = imap.idle().expect("Could not IDLE");
-
     // Implement a trivial counter that causes the IDLE callback to end the IDLE
     // after a fixed number of responses.
     //
@@ -63,7 +61,7 @@ fn main() {
     // rest of the program and update mailbox state, decide to exit the IDLE, etc.
     let mut num_responses = 0;
     let max_responses = opt.max_responses;
-    let idle_result = idle.wait_keepalive_while(|response| {
+    let idle_result = imap.idle().wait_while(|response| {
         num_responses += 1;
         println!("IDLE response #{}: {:?}", num_responses, response);
         if num_responses >= max_responses {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1093,7 +1093,7 @@ impl<T: Read + Write> Session<T> {
     /// command, as specified in the base IMAP specification.
     ///
     /// See [`extensions::idle::Handle`] for details.
-    pub fn idle(&mut self) -> Result<extensions::idle::Handle<'_, T>> {
+    pub fn idle(&mut self) -> extensions::idle::Handle<'_, T> {
         extensions::idle::Handle::make(self)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -284,7 +284,7 @@ impl<T: Read + Write> Client<T> {
     /// # use imap::Client;
     /// # use std::io;
     /// # use std::net::TcpStream;
-    /// # {} #[cfg(feature = "tls")]
+    /// # {} #[cfg(feature = "native-tls")]
     /// # fn main() {
     /// # let server = "imap.example.com";
     /// # let username = "";
@@ -325,7 +325,7 @@ impl<T: Read + Write> Client<T> {
     /// transferred back to the caller.
     ///
     /// ```rust,no_run
-    /// # {} #[cfg(feature = "tls")]
+    /// # {} #[cfg(feature = "native-tls")]
     /// # fn main() {
     /// let client = imap::ClientBuilder::new("imap.example.org", 993)
     ///     .native_tls().unwrap();
@@ -376,7 +376,7 @@ impl<T: Read + Write> Client<T> {
     ///     }
     /// }
     ///
-    /// # {} #[cfg(feature = "tls")]
+    /// # {} #[cfg(feature = "native-tls")]
     /// fn main() {
     ///     let auth = OAuth2 {
     ///         user: String::from("me@example.com"),

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -2,7 +2,7 @@ use crate::{Client, Result};
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::{TlsConnector, TlsStream};
 #[cfg(feature = "rustls-tls")]
 use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
@@ -12,7 +12,7 @@ use rustls_connector::{RustlsConnector, TlsStream as RustlsStream};
 /// Creating a [`Client`] using `native-tls` transport is straightforward:
 /// ```no_run
 /// # use imap::ClientBuilder;
-/// # {} #[cfg(feature = "tls")]
+/// # {} #[cfg(feature = "native-tls")]
 /// # fn main() -> Result<(), imap::Error> {
 /// let client = ClientBuilder::new("imap.example.com", 993).native_tls()?;
 /// # Ok(())
@@ -66,15 +66,15 @@ where
     }
 
     /// Use [`STARTTLS`](https://tools.ietf.org/html/rfc2595) for this connection.
-    #[cfg(any(feature = "tls", feature = "rustls-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     pub fn starttls(&mut self) -> &mut Self {
         self.starttls = true;
         self
     }
 
     /// Return a new [`Client`] using a `native-tls` transport.
-    #[cfg(feature = "tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn native_tls(&mut self) -> Result<Client<TlsStream<TcpStream>>> {
         self.connect(|domain, tcp| {
             let ssl_conn = TlsConnector::builder().build()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,9 +10,9 @@ use std::str::Utf8Error;
 use base64::DecodeError;
 use bufstream::IntoInnerError as BufError;
 use imap_proto::{types::ResponseCode, Response};
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::Error as TlsError;
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::HandshakeError as TlsHandshakeError;
 #[cfg(feature = "rustls-tls")]
 use rustls_connector::HandshakeError as RustlsHandshakeError;
@@ -62,10 +62,10 @@ pub enum Error {
     #[cfg(feature = "rustls-tls")]
     RustlsHandshake(RustlsHandshakeError<TcpStream>),
     /// An error from the `native_tls` library during the TLS handshake.
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "native-tls")]
     TlsHandshake(TlsHandshakeError<TcpStream>),
     /// An error from the `native_tls` library while managing the socket.
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "native-tls")]
     Tls(TlsError),
     /// A BAD response from the IMAP server.
     Bad(Bad),
@@ -114,14 +114,14 @@ impl From<RustlsHandshakeError<TcpStream>> for Error {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 impl From<TlsHandshakeError<TcpStream>> for Error {
     fn from(err: TlsHandshakeError<TcpStream>) -> Error {
         Error::TlsHandshake(err)
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 impl From<TlsError> for Error {
     fn from(err: TlsError) -> Error {
         Error::Tls(err)
@@ -140,9 +140,9 @@ impl fmt::Display for Error {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "rustls-tls")]
             Error::RustlsHandshake(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::Tls(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::TlsHandshake(ref e) => fmt::Display::fmt(e, f),
             Error::Validate(ref e) => fmt::Display::fmt(e, f),
             Error::Parse(ref e) => fmt::Display::fmt(e, f),
@@ -163,9 +163,9 @@ impl StdError for Error {
             Error::Io(ref e) => e.description(),
             #[cfg(feature = "rustls-tls")]
             Error::RustlsHandshake(ref e) => e.description(),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::Tls(ref e) => e.description(),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::TlsHandshake(ref e) => e.description(),
             Error::Parse(ref e) => e.description(),
             Error::Validate(ref e) => e.description(),
@@ -183,9 +183,9 @@ impl StdError for Error {
             Error::Io(ref e) => Some(e),
             #[cfg(feature = "rustls-tls")]
             Error::RustlsHandshake(ref e) => Some(e),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::Tls(ref e) => Some(e),
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "native-tls")]
             Error::TlsHandshake(ref e) => Some(e),
             Error::Parse(ParseError::DataNotUtf8(_, ref e)) => Some(e),
             _ => None,

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -206,7 +206,7 @@ impl<'a, T: SetReadTimeout + Read + Write + 'a> Handle<'a, T> {
     /// Do not continuously refresh the IDLE connection in the background.
     ///
     /// By default, connections will periodically be refreshed in the background using the
-    /// timeout duration set by [`timeout`]. If you do not want this behaviour, call
+    /// timeout duration set by [`Handle::timeout`]. If you do not want this behaviour, call
     /// this function and the connection will simply IDLE until `wait_while` returns or
     /// the timeout expires.
     pub fn keepalive(&mut self, keepalive: bool) -> &mut Self {

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -19,10 +19,11 @@ use std::time::Duration;
 /// specificed in [RFC 2177](https://tools.ietf.org/html/rfc2177) until the underlying server state
 /// changes in some way.
 ///
-/// Each of the `wait` functions takes a callback function which receives any responses
+/// The `wait_while` function takes a callback function which receives any responses
 /// that arrive on the channel while IDLE. The callback function implements whatever
 /// logic is needed to handle the IDLE response, and then returns a boolean
 /// to continue idling (`true`) or stop (`false`).
+///
 /// For users that want the IDLE to exit on any change (the behavior proior to version 3.0),
 /// a convenience callback function [`stop_on_any`] is provided.
 ///
@@ -37,25 +38,24 @@ use std::time::Duration;
 /// imap.select("INBOX")
 ///     .expect("Could not select mailbox");
 ///
-/// let idle = imap.idle().expect("Could not IDLE");
-///
-/// // Exit on any mailbox change
-/// let result = idle.wait_keepalive_while(idle::stop_on_any);
+/// // Exit on any mailbox change. By default, connections will be periodically
+/// // refreshed in the background.
+/// let result = imap.idle().wait_while(idle::stop_on_any);
 /// # }
 /// ```
 ///
 /// Note that the server MAY consider a client inactive if it has an IDLE command running, and if
 /// such a server has an inactivity timeout it MAY log the client off implicitly at the end of its
-/// timeout period.  Because of that, clients using IDLE are advised to terminate the IDLE and
-/// re-issue it at least every 29 minutes to avoid being logged off. [`Handle::wait_keepalive_while`]
-/// does this. This still allows a client to receive immediate mailbox updates even though it need
-/// only "poll" at half hour intervals.
+/// timeout period. Because of that, clients using IDLE are advised to terminate the IDLE and
+/// re-issue it at least every 29 minutes to avoid being logged off. This is done by default, but
+/// can be disabled by calling [`Handle::no_keepalive`]
 ///
 /// As long as a [`Handle`] is active, the mailbox cannot be otherwise accessed.
 #[derive(Debug)]
 pub struct Handle<'a, T: Read + Write> {
     session: &'a mut Session<T>,
-    keepalive: Duration,
+    timeout: Duration,
+    keepalive: bool,
     done: bool,
 }
 
@@ -73,11 +73,7 @@ pub fn stop_on_any(_response: UnsolicitedResponse) -> bool {
     false
 }
 
-/// Must be implemented for a transport in order for a `Session` using that transport to support
-/// operations with timeouts.
-///
-/// Examples of where this is useful is for `Handle::wait_keepalive_while` and
-/// `Handle::wait_timeout_while`.
+/// Must be implemented for a transport in order for a `Session` to use IDLE.
 pub trait SetReadTimeout {
     /// Set the timeout for subsequent reads to the given one.
     ///
@@ -88,14 +84,13 @@ pub trait SetReadTimeout {
 }
 
 impl<'a, T: Read + Write + 'a> Handle<'a, T> {
-    pub(crate) fn make(session: &'a mut Session<T>) -> Result<Self> {
-        let mut h = Handle {
+    pub(crate) fn make(session: &'a mut Session<T>) -> Self {
+        Handle {
             session,
-            keepalive: Duration::from_secs(29 * 60),
+            timeout: Duration::from_secs(29 * 60),
+            keepalive: true,
             done: false,
-        };
-        h.init()?;
-        Ok(h)
+        }
     }
 
     fn init(&mut self) -> Result<()> {
@@ -132,7 +127,7 @@ impl<'a, T: Read + Write + 'a> Handle<'a, T> {
 
     /// Internal helper that doesn't consume self.
     ///
-    /// This is necessary so that we can keep using the inner `Session` in `wait_keepalive_while`.
+    /// This is necessary so that we can keep using the inner `Session` in `wait_while`.
     fn wait_inner<F>(&mut self, reconnect: bool, mut callback: F) -> Result<WaitOutcome>
     where
         F: FnMut(UnsolicitedResponse) -> bool,
@@ -196,38 +191,36 @@ impl<'a, T: Read + Write + 'a> Handle<'a, T> {
             (_, result) => result,
         }
     }
-
-    /// Block until the given callback returns `false`, or until a response
-    /// arrives that is not explicitly handled by [`UnsolicitedResponse`].
-    pub fn wait_while<F>(mut self, callback: F) -> Result<()>
-    where
-        F: FnMut(UnsolicitedResponse) -> bool,
-    {
-        self.wait_inner(true, callback).map(|_| ())
-    }
 }
 
 impl<'a, T: SetReadTimeout + Read + Write + 'a> Handle<'a, T> {
-    /// Set the keep-alive interval to use when `wait_keepalive_while` is called.
+    /// Set the timeout duration on the connection. This will also set the frequency
+    /// at which the connection is refreshed.
     ///
-    /// The interval defaults to 29 minutes as dictated by RFC 2177.
-    pub fn set_keepalive(&mut self, interval: Duration) {
-        self.keepalive = interval;
+    /// The interval defaults to 29 minutes as given in RFC 2177.
+    pub fn set_timeout(&mut self, interval: Duration) -> &mut Self {
+        self.timeout = interval;
+        self
+    }
+
+    /// Do not continuously refresh the IDLE connection in the background.
+    ///
+    /// By default, connections will periodically be refreshed in the background using the
+    /// timeout duration set by [`set_timeout`]. If you do not want this behaviour, call
+    /// this function and the connection will simply IDLE until `wait_while` returns or
+    /// the timeout expires.
+    pub fn no_keepalive(&mut self) -> &mut Self {
+        self.keepalive = false;
+        self
     }
 
     /// Block until the given callback returns `false`, or until a response
     /// arrives that is not explicitly handled by [`UnsolicitedResponse`].
-    ///
-    /// This method differs from [`Handle::wait_while`] in that it will periodically refresh the IDLE
-    /// connection, to prevent the server from timing out our connection. The keepalive interval is
-    /// set to 29 minutes by default, as dictated by RFC 2177, but can be changed using
-    /// [`Handle::set_keepalive`].
-    ///
-    /// This is the recommended method to use for waiting.
-    pub fn wait_keepalive_while<F>(self, callback: F) -> Result<()>
+    pub fn wait_while<F>(&mut self, callback: F) -> Result<()>
     where
         F: FnMut(UnsolicitedResponse) -> bool,
     {
+        self.init()?;
         // The server MAY consider a client inactive if it has an IDLE command
         // running, and if such a server has an inactivity timeout it MAY log
         // the client off implicitly at the end of its timeout period.  Because
@@ -235,34 +228,18 @@ impl<'a, T: SetReadTimeout + Read + Write + 'a> Handle<'a, T> {
         // re-issue it at least every 29 minutes to avoid being logged off.
         // This still allows a client to receive immediate mailbox updates even
         // though it need only "poll" at half hour intervals.
-        let keepalive = self.keepalive;
-        self.timed_wait(keepalive, true, callback).map(|_| ())
+        self.timed_wait(callback).map(|_| ())
     }
 
-    /// Block until the given given amount of time has elapsed, the given callback
-    /// returns `false`, or until a response arrives that is not explicitly handled
-    /// by [`UnsolicitedResponse`].
-    pub fn wait_with_timeout_while<F>(self, timeout: Duration, callback: F) -> Result<WaitOutcome>
-    where
-        F: FnMut(UnsolicitedResponse) -> bool,
-    {
-        self.timed_wait(timeout, false, callback)
-    }
-
-    fn timed_wait<F>(
-        mut self,
-        timeout: Duration,
-        reconnect: bool,
-        callback: F,
-    ) -> Result<WaitOutcome>
+    fn timed_wait<F>(&mut self, callback: F) -> Result<WaitOutcome>
     where
         F: FnMut(UnsolicitedResponse) -> bool,
     {
         self.session
             .stream
             .get_mut()
-            .set_read_timeout(Some(timeout))?;
-        let res = self.wait_inner(reconnect, callback);
+            .set_read_timeout(Some(self.timeout))?;
+        let res = self.wait_inner(self.keepalive, callback);
         let _ = self.session.stream.get_mut().set_read_timeout(None).is_ok();
         res
     }

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -5,7 +5,7 @@ use crate::client::Session;
 use crate::error::{Error, Result};
 use crate::parse::parse_idle;
 use crate::types::UnsolicitedResponse;
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 use native_tls::TlsStream;
 #[cfg(feature = "rustls-tls")]
 use rustls_connector::TlsStream as RustlsStream;
@@ -28,7 +28,7 @@ use std::time::Duration;
 ///
 /// ```no_run
 /// use imap::extensions::idle;
-/// # #[cfg(feature = "tls")]
+/// # #[cfg(feature = "native-tls")]
 /// # {
 /// let client = imap::ClientBuilder::new("example.com", 993).native_tls()
 ///     .expect("Could not connect to imap server");
@@ -281,7 +281,7 @@ impl<'a> SetReadTimeout for TcpStream {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls")]
 impl<'a> SetReadTimeout for TlsStream<TcpStream> {
     fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<()> {
         self.get_ref().set_read_timeout(timeout).map_err(Error::Io)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Below is a basic client example. See the `examples/` directory for more.
 //!
 //! ```no_run
-//! # #[cfg(feature = "tls")]
+//! # #[cfg(feature = "native-tls")]
 //! fn fetch_inbox_top() -> imap::error::Result<Option<String>> {
 //!
 //!     let client = imap::ClientBuilder::new("imap.example.com", 993).native_tls()?;

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -18,7 +18,7 @@ use std::ops::RangeInclusive;
 ///
 /// # Examples
 /// ```no_run
-/// # {} #[cfg(feature = "tls")]
+/// # {} #[cfg(feature = "native-tls")]
 /// # fn main() {
 /// # let client = imap::ClientBuilder::new("imap.example.com", 993)
 ///     .native_tls().unwrap();

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -456,7 +456,9 @@ fn status() {
 
     // Test all valid fields except HIGHESTMODSEQ, which apparently
     // isn't supported by the IMAP server used for this test.
-    let mb = s.status("INBOX", "(MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)").unwrap();
+    let mb = s
+        .status("INBOX", "(MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)")
+        .unwrap();
     assert_eq!(mb.flags, Vec::new());
     assert_eq!(mb.exists, 0);
     assert_eq!(mb.recent, 0);


### PR DESCRIPTION
Addresses #191 .

Also includes the changes in #201 for convenience.

Note that this change effectively requires that the underlying transport implements the `SetReadTimeout` trait from `extensions::idle`. I am not sure if this is a problem or not. If so, I can add the old `wait_while()` back with a different name (`wait_notimeout_while()`?) to restore the functionality. I opted to remove it because the old `wait_keepalive_while` function was already broken for non-`SetReadTimeout` transports, and it was the recommended way to do it. I am unsure if the extra API is worth it since implementing `SetReadTimeout` is so trivial. Happy to get feedback on this.

Note that this also makes `keepalive` the default, since it is the recommended way to do it. An opt-out function is provided (`no_keepalive()`) for users who do not want this. I figured that the recommended path should also be the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/202)
<!-- Reviewable:end -->
