### PR TITLE
Flag static

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -177,6 +177,24 @@ impl Flag<'static> {
     }
 }
 
+impl<'flag> Flag<'flag> {
+    /// Converts a `Flag<'flag>` into a `Flag<'static>` or in other words: It's
+    /// making sure that `Flag::Custom` includes a `String` and not a `&str`
+    /// anymore.
+    pub fn into_static(&self) -> Flag<'static> {
+        match self {
+            Flag::Seen => Flag::Seen,
+            Flag::Answered => Flag::Answered,
+            Flag::Flagged => Flag::Flagged,
+            Flag::Deleted => Flag::Deleted,
+            Flag::Draft => Flag::Draft,
+            Flag::Recent => Flag::Recent,
+            Flag::MayCreate => Flag::MayCreate,
+            Flag::Custom(cow) => Flag::Custom(Cow::Owned(cow.to_string())),
+        }
+    }
+}
+
 impl<'a> fmt::Display for Flag<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {


### PR DESCRIPTION
Adding a function which will makes it possible to convert a `Flag<'a>` into a
`Flag<'static>` in order to be able to store flags.

This should also fix [my issue](https://github.com/jonhoo/rust-imap/issues/205).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/206)
<!-- Reviewable:end -->
