### PR TITLE
Convert ZeroCopy to ouroboros.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imap"
-version = "3.0.0-alpha.4"
+version = "3.0.0-alpha.5"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>",
            "Matt McCoy <mattnenterprise@yahoo.com>"]
 documentation = "https://docs.rs/imap/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ nom = { version = "6.0", default-features = false }
 base64 = "0.13"
 chrono = { version = "0.4", default-features = false, features = ["std"]}
 lazy_static = "1.4"
+ouroboros = "0.9.5"
 
 [dev-dependencies]
 lettre = "0.9"

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -42,7 +42,7 @@ fn main() {
 
     match imap_session.fetch("2", "body[text]") {
         Ok(msgs) => {
-            for msg in &msgs {
+            for msg in msgs.iter() {
                 print!("{:?}", msg);
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -565,39 +565,39 @@ impl<T: Read + Write> Session<T> {
     ///  - `RFC822.HEADER`: Functionally equivalent to `BODY.PEEK[HEADER]`.
     ///  - `RFC822.SIZE`: The [RFC-2822](https://tools.ietf.org/html/rfc2822) size of the message.
     ///  - `UID`: The unique identifier for the message.
-    pub fn fetch<S1, S2>(&mut self, sequence_set: S1, query: S2) -> ZeroCopyResult<Vec<Fetch>>
+    pub fn fetch<S1, S2>(&mut self, sequence_set: S1, query: S2) -> Result<Fetches>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
         if sequence_set.as_ref().is_empty() {
-            parse_fetches(vec![], &mut self.unsolicited_responses_tx)
+            Fetches::parse(vec![], &mut self.unsolicited_responses_tx)
         } else {
             self.run_command_and_read_response(&format!(
                 "FETCH {} {}",
                 validate_sequence_set(sequence_set.as_ref())?,
                 validate_str_noquote(query.as_ref())?
             ))
-            .and_then(|lines| parse_fetches(lines, &mut self.unsolicited_responses_tx))
+            .and_then(|lines| Fetches::parse(lines, &mut self.unsolicited_responses_tx))
         }
     }
 
     /// Equivalent to [`Session::fetch`], except that all identifiers in `uid_set` are
     /// [`Uid`]s. See also the [`UID` command](https://tools.ietf.org/html/rfc3501#section-6.4.8).
-    pub fn uid_fetch<S1, S2>(&mut self, uid_set: S1, query: S2) -> ZeroCopyResult<Vec<Fetch>>
+    pub fn uid_fetch<S1, S2>(&mut self, uid_set: S1, query: S2) -> Result<Fetches>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
         if uid_set.as_ref().is_empty() {
-            parse_fetches(vec![], &mut self.unsolicited_responses_tx)
+            Fetches::parse(vec![], &mut self.unsolicited_responses_tx)
         } else {
             self.run_command_and_read_response(&format!(
                 "UID FETCH {} {}",
                 validate_sequence_set(uid_set.as_ref())?,
                 validate_str_noquote(query.as_ref())?
             ))
-            .and_then(|lines| parse_fetches(lines, &mut self.unsolicited_responses_tx))
+            .and_then(|lines| Fetches::parse(lines, &mut self.unsolicited_responses_tx))
         }
     }
 
@@ -834,7 +834,7 @@ impl<T: Read + Write> Session<T> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn store<S1, S2>(&mut self, sequence_set: S1, query: S2) -> ZeroCopyResult<Vec<Fetch>>
+    pub fn store<S1, S2>(&mut self, sequence_set: S1, query: S2) -> Result<Fetches>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
@@ -844,12 +844,12 @@ impl<T: Read + Write> Session<T> {
             sequence_set.as_ref(),
             query.as_ref()
         ))
-        .and_then(|lines| parse_fetches(lines, &mut self.unsolicited_responses_tx))
+        .and_then(|lines| Fetches::parse(lines, &mut self.unsolicited_responses_tx))
     }
 
     /// Equivalent to [`Session::store`], except that all identifiers in `sequence_set` are
     /// [`Uid`]s. See also the [`UID` command](https://tools.ietf.org/html/rfc3501#section-6.4.8).
-    pub fn uid_store<S1, S2>(&mut self, uid_set: S1, query: S2) -> ZeroCopyResult<Vec<Fetch>>
+    pub fn uid_store<S1, S2>(&mut self, uid_set: S1, query: S2) -> Result<Fetches>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
@@ -859,7 +859,7 @@ impl<T: Read + Write> Session<T> {
             uid_set.as_ref(),
             query.as_ref()
         ))
-        .and_then(|lines| parse_fetches(lines, &mut self.unsolicited_responses_tx))
+        .and_then(|lines| Fetches::parse(lines, &mut self.unsolicited_responses_tx))
     }
 
     /// The [`COPY` command](https://tools.ietf.org/html/rfc3501#section-6.4.7) copies the
@@ -988,13 +988,13 @@ impl<T: Read + Write> Session<T> {
         &mut self,
         reference_name: Option<&str>,
         mailbox_pattern: Option<&str>,
-    ) -> ZeroCopyResult<Vec<Name>> {
+    ) -> Result<Names> {
         self.run_command_and_read_response(&format!(
             "LIST {} {}",
             quote!(reference_name.unwrap_or("")),
             mailbox_pattern.unwrap_or("\"\"")
         ))
-        .and_then(|lines| parse_names(lines, &mut self.unsolicited_responses_tx))
+        .and_then(|lines| Names::parse(lines, &mut self.unsolicited_responses_tx))
     }
 
     /// The [`LSUB` command](https://tools.ietf.org/html/rfc3501#section-6.3.9) returns a subset of
@@ -1016,13 +1016,13 @@ impl<T: Read + Write> Session<T> {
         &mut self,
         reference_name: Option<&str>,
         mailbox_pattern: Option<&str>,
-    ) -> ZeroCopyResult<Vec<Name>> {
+    ) -> Result<Names> {
         self.run_command_and_read_response(&format!(
             "LSUB {} {}",
             quote!(reference_name.unwrap_or("")),
             mailbox_pattern.unwrap_or("")
         ))
-        .and_then(|lines| parse_names(lines, &mut self.unsolicited_responses_tx))
+        .and_then(|lines| Names::parse(lines, &mut self.unsolicited_responses_tx))
     }
 
     /// The [`STATUS` command](https://tools.ietf.org/html/rfc3501#section-6.3.10) requests the

--- a/src/client.rs
+++ b/src/client.rs
@@ -717,9 +717,9 @@ impl<T: Read + Write> Session<T> {
     /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
     /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
     /// one of the listed capabilities. See [`Capabilities`] for further details.
-    pub fn capabilities(&mut self) -> ZeroCopyResult<Capabilities> {
+    pub fn capabilities(&mut self) -> Result<Capabilities> {
         self.run_command_and_read_response("CAPABILITY")
-            .and_then(|lines| parse_capabilities(lines, &mut self.unsolicited_responses_tx))
+            .and_then(|lines| Capabilities::parse(lines, &mut self.unsolicited_responses_tx))
     }
 
     /// The [`EXPUNGE` command](https://tools.ietf.org/html/rfc3501#section-6.4.3) permanently

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -54,7 +54,7 @@ where
                 lines = rest;
 
                 match map(resp)? {
-                    MapOrNot::Map(t) => into.extend(Some(t)),
+                    MapOrNot::Map(t) => into.extend(std::iter::once(t)),
                     MapOrNot::MapVec(t) => into.extend(t),
                     MapOrNot::Not(resp) => match try_handle_unilateral(resp, unsolicited) {
                         Some(Response::Fetch(..)) => continue,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -414,7 +414,7 @@ mod tests {
         let names = Names::parse(lines.to_vec(), &mut send).unwrap();
         assert!(recv.try_recv().is_err());
         assert_eq!(names.len(), 1);
-        let first = names.iter().next().unwrap();
+        let first = names.get(0).unwrap();
         assert_eq!(
             first.attributes(),
             &[NameAttribute::from("\\HasNoChildren")]
@@ -441,14 +441,13 @@ mod tests {
         let fetches = Fetches::parse(lines.to_vec(), &mut send).unwrap();
         assert!(recv.try_recv().is_err());
         assert_eq!(fetches.len(), 2);
-        let mut iter = fetches.iter();
-        let first = iter.next().unwrap();
+        let first = fetches.get(0).unwrap();
         assert_eq!(first.message, 24);
         assert_eq!(first.flags(), &[Flag::Seen]);
         assert_eq!(first.uid, Some(4827943));
         assert_eq!(first.body(), None);
         assert_eq!(first.header(), None);
-        let second = iter.next().unwrap();
+        let second = fetches.get(1).unwrap();
         assert_eq!(second.message, 25);
         assert_eq!(second.flags(), &[Flag::Seen]);
         assert_eq!(second.uid, None);
@@ -466,7 +465,7 @@ mod tests {
         let fetches = Fetches::parse(lines.to_vec(), &mut send).unwrap();
         assert_eq!(recv.try_recv(), Ok(UnsolicitedResponse::Recent(1)));
         assert_eq!(fetches.len(), 1);
-        let first = fetches.iter().next().unwrap();
+        let first = fetches.get(0).unwrap();
         assert_eq!(first.message, 37);
         assert_eq!(first.uid, Some(74));
     }
@@ -489,7 +488,7 @@ mod tests {
             })
         );
         assert_eq!(fetches.len(), 1);
-        let first = fetches.iter().next().unwrap();
+        let first = fetches.get(0).unwrap();
         assert_eq!(first.message, 37);
         assert_eq!(first.uid, Some(74));
     }
@@ -505,7 +504,7 @@ mod tests {
         assert_eq!(recv.try_recv().unwrap(), UnsolicitedResponse::Expunge(4));
 
         assert_eq!(names.len(), 1);
-        let first = names.iter().next().unwrap();
+        let first = names.get(0).unwrap();
         assert_eq!(
             first.attributes(),
             &[NameAttribute::from("\\HasNoChildren")]
@@ -658,7 +657,7 @@ mod tests {
         }
         assert!(recv.try_recv().is_err());
         assert_eq!(fetches.len(), 1);
-        let first = fetches.iter().next().unwrap();
+        let first = fetches.get(0).unwrap();
         assert_eq!(first.message, 49);
         assert_eq!(first.flags(), &[Flag::Seen, Flag::Answered]);
         assert_eq!(first.uid, Some(117));

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -71,6 +71,16 @@ impl Fetches {
     pub fn iter(&self) -> Iter<'_, Fetch<'_>> {
         self.borrow_fetches().iter()
     }
+
+    /// Get the number of [`Fetch`]es in this container.
+    pub fn len(&self) -> usize {
+        self.borrow_fetches().len()
+    }
+
+    /// Return true if there are no [`Fetch`]es in the container.
+    pub fn is_empty(&self) -> bool {
+        self.borrow_fetches().is_empty()
+    }
 }
 
 /// An IMAP [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2) that contains

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -1,17 +1,83 @@
 use super::{Flag, Seq, Uid};
+use crate::error::Error;
+use crate::parse::{parse_many_into, MapOrNot};
+use crate::types::UnsolicitedResponse;
 use chrono::{DateTime, FixedOffset};
-use imap_proto::types::{AttributeValue, BodyStructure, Envelope, MessageSection, SectionPath};
+use imap_proto::types::{
+    AttributeValue, BodyStructure, Envelope, MessageSection, Response, SectionPath,
+};
+use ouroboros::self_referencing;
+use std::slice::Iter;
+use std::sync::mpsc;
 
 /// Format of Date and Time as defined RFC3501.
 /// See `date-time` element in [Formal Syntax](https://tools.ietf.org/html/rfc3501#section-9)
 /// chapter of this RFC.
 const DATE_TIME_FORMAT: &str = "%d-%b-%Y %H:%M:%S %z";
 
+/// A wrapper for one or more [`Fetch`] responses.
+#[self_referencing]
+pub struct Fetches {
+    data: Vec<u8>,
+    #[borrows(data)]
+    #[covariant]
+    pub(crate) fetches: Vec<Fetch<'this>>,
+}
+
+impl Fetches {
+    /// Parse one or more [`Fetch`] responses from a response buffer.
+    pub fn parse(
+        owned: Vec<u8>,
+        unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
+    ) -> Result<Self, Error> {
+        FetchesTryBuilder {
+            data: owned,
+            fetches_builder: |input| {
+                let mut fetches = Vec::new();
+                parse_many_into(input, &mut fetches, unsolicited, |response| {
+                    match response {
+                        Response::Fetch(num, attrs) => {
+                            let mut fetch = Fetch {
+                                message: num,
+                                flags: vec![],
+                                uid: None,
+                                size: None,
+                                fetch: attrs,
+                            };
+
+                            // set some common fields eagerly
+                            for attr in &fetch.fetch {
+                                match attr {
+                                    AttributeValue::Flags(flags) => {
+                                        fetch.flags.extend(Flag::from_strs(flags));
+                                    }
+                                    AttributeValue::Uid(uid) => fetch.uid = Some(*uid),
+                                    AttributeValue::Rfc822Size(sz) => fetch.size = Some(*sz),
+                                    _ => {}
+                                }
+                            }
+                            Ok(MapOrNot::Map(fetch))
+                        }
+                        resp => Ok(MapOrNot::Not(resp)),
+                    }
+                })?;
+                Ok(fetches)
+            },
+        }
+        .try_build()
+    }
+
+    /// Iterate over the contained [`Fetch`]es.
+    pub fn iter(&self) -> Iter<'_, Fetch<'_>> {
+        self.borrow_fetches().iter()
+    }
+}
+
 /// An IMAP [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2) that contains
 /// data about a particular message. This response occurs as the result of a `FETCH` or `STORE`
 /// command, as well as by unilateral server decision (e.g., flag updates).
 #[derive(Debug, Eq, PartialEq)]
-pub struct Fetch {
+pub struct Fetch<'a> {
     /// The ordinal number of this message in its containing mailbox.
     pub message: Seq,
 
@@ -24,16 +90,13 @@ pub struct Fetch {
     /// Only present if `RFC822.SIZE` was specified in the query argument to `FETCH`.
     pub size: Option<u32>,
 
-    // Note that none of these fields are *actually* 'static. Rather, they are tied to the lifetime
-    // of the `ZeroCopy` that contains this `Name`. That's also why they can't be public -- we can
-    // only return them with a lifetime tied to self.
-    pub(crate) fetch: Vec<AttributeValue<'static>>,
+    pub(crate) fetch: Vec<AttributeValue<'a>>,
     pub(crate) flags: Vec<Flag<'static>>,
 }
 
-impl Fetch {
+impl<'a> Fetch<'a> {
     /// A list of flags that are set for this message.
-    pub fn flags(&self) -> &[Flag<'_>] {
+    pub fn flags(&self) -> &[Flag<'a>] {
         &self.flags[..]
     }
 
@@ -134,7 +197,7 @@ impl Fetch {
     ///
     /// See [section 2.3.6 of RFC 3501](https://tools.ietf.org/html/rfc3501#section-2.3.6) for
     /// details.
-    pub fn bodystructure<'a>(&self) -> Option<&BodyStructure<'a>> {
+    pub fn bodystructure(&self) -> Option<&BodyStructure<'a>> {
         self.fetch.iter().find_map(|av| match av {
             AttributeValue::BodyStructure(bs) => Some(bs),
             _ => None,

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -213,4 +213,15 @@ impl<'a> Fetch<'a> {
             _ => None,
         })
     }
+
+    /// Get an owned copy of the [`Fetch`].
+    pub fn into_owned(self) -> Fetch<'static> {
+        Fetch {
+            message: self.message,
+            uid: self.uid,
+            size: self.size,
+            fetch: self.fetch.into_iter().map(|av| av.into_owned()).collect(),
+            flags: self.flags.clone(),
+        }
+    }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -81,6 +81,11 @@ impl Fetches {
     pub fn is_empty(&self) -> bool {
         self.borrow_fetches().is_empty()
     }
+
+    /// Get the element at the given index
+    pub fn get(&self, index: usize) -> Option<&Fetch<'_>> {
+        self.borrow_fetches().get(index)
+    }
 }
 
 /// An IMAP [`FETCH` response](https://tools.ietf.org/html/rfc3501#section-7.4.2) that contains

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -1,0 +1,108 @@
+use std::borrow::Cow;
+
+/// With the exception of [`Flag::Custom`], these flags are system flags that are pre-defined in
+/// [RFC 3501 section 2.3.2](https://tools.ietf.org/html/rfc3501#section-2.3.2). All system flags
+/// begin with `\` in the IMAP protocol.  Certain system flags (`\Deleted` and `\Seen`) have
+/// special semantics described elsewhere.
+///
+/// A flag can be permanent or session-only on a per-flag basis. Permanent flags are those which
+/// the client can add or remove from the message flags permanently; that is, concurrent and
+/// subsequent sessions will see any change in permanent flags.  Changes to session flags are valid
+/// only in that session.
+///
+/// > Note: The `\Recent` system flag is a special case of a session flag.  `\Recent` can not be
+/// > used as an argument in a `STORE` or `APPEND` command, and thus can not be changed at all.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Flag<'a> {
+    /// Message has been read
+    Seen,
+
+    /// Message has been answered
+    Answered,
+
+    /// Message is "flagged" for urgent/special attention
+    Flagged,
+
+    /// Message is "deleted" for removal by later EXPUNGE
+    Deleted,
+
+    /// Message has not completed composition (marked as a draft).
+    Draft,
+
+    /// Message is "recently" arrived in this mailbox.  This session is the first session to have
+    /// been notified about this message; if the session is read-write, subsequent sessions will
+    /// not see `\Recent` set for this message.  This flag can not be altered by the client.
+    ///
+    /// If it is not possible to determine whether or not this session is the first session to be
+    /// notified about a message, then that message will generally be considered recent.
+    ///
+    /// If multiple connections have the same mailbox selected simultaneously, it is undefined
+    /// which of these connections will see newly-arrived messages with `\Recent` set and which
+    /// will see it without `\Recent` set.
+    Recent,
+
+    /// The [`Mailbox::permanent_flags`] can include this special flag (`\*`), which indicates that
+    /// it is possible to create new keywords by attempting to store those flags in the mailbox.
+    MayCreate,
+
+    /// A non-standard user- or server-defined flag.
+    Custom(Cow<'a, str>),
+}
+
+impl Flag<'static> {
+    fn system(s: &str) -> Option<Self> {
+        match s {
+            "\\Seen" => Some(Flag::Seen),
+            "\\Answered" => Some(Flag::Answered),
+            "\\Flagged" => Some(Flag::Flagged),
+            "\\Deleted" => Some(Flag::Deleted),
+            "\\Draft" => Some(Flag::Draft),
+            "\\Recent" => Some(Flag::Recent),
+            "\\*" => Some(Flag::MayCreate),
+            _ => None,
+        }
+    }
+
+    /// Helper function to transform Strings into owned Flags
+    pub fn from_strs<S: ToString>(
+        v: impl IntoIterator<Item = S>,
+    ) -> impl Iterator<Item = Flag<'static>> {
+        v.into_iter().map(|s| Flag::from(s.to_string()))
+    }
+}
+
+impl<'a> std::fmt::Display for Flag<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Flag::Seen => write!(f, "\\Seen"),
+            Flag::Answered => write!(f, "\\Answered"),
+            Flag::Flagged => write!(f, "\\Flagged"),
+            Flag::Deleted => write!(f, "\\Deleted"),
+            Flag::Draft => write!(f, "\\Draft"),
+            Flag::Recent => write!(f, "\\Recent"),
+            Flag::MayCreate => write!(f, "\\*"),
+            Flag::Custom(ref s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl<'a> From<String> for Flag<'a> {
+    fn from(s: String) -> Self {
+        if let Some(f) = Flag::system(&s) {
+            f
+        } else {
+            Flag::Custom(Cow::Owned(s))
+        }
+    }
+}
+
+impl<'a> From<&'a str> for Flag<'a> {
+    fn from(s: &'a str) -> Self {
+        if let Some(f) = Flag::system(s) {
+            f
+        } else {
+            Flag::Custom(Cow::Borrowed(s))
+        }
+    }
+}

--- a/src/types/flag.rs
+++ b/src/types/flag.rs
@@ -72,6 +72,22 @@ impl Flag<'static> {
     }
 }
 
+impl<'a> Flag<'a> {
+    /// Get an owned version of the [`Flag`].
+    pub fn into_owned(self) -> Flag<'static> {
+        match self {
+            Flag::Custom(cow) => Flag::Custom(Cow::Owned(cow.into_owned())),
+            Flag::Seen => Flag::Seen,
+            Flag::Answered => Flag::Answered,
+            Flag::Flagged => Flag::Flagged,
+            Flag::Deleted => Flag::Deleted,
+            Flag::Draft => Flag::Draft,
+            Flag::Recent => Flag::Recent,
+            Flag::MayCreate => Flag::MayCreate,
+        }
+    }
+}
+
 impl<'a> std::fmt::Display for Flag<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -104,6 +104,18 @@ impl NameAttribute<'static> {
     }
 }
 
+impl<'a> NameAttribute<'a> {
+    fn into_owned(self) -> NameAttribute<'static> {
+        match self {
+            NameAttribute::NoInferiors => NameAttribute::NoInferiors,
+            NameAttribute::NoSelect => NameAttribute::NoSelect,
+            NameAttribute::Marked => NameAttribute::Marked,
+            NameAttribute::Unmarked => NameAttribute::Unmarked,
+            NameAttribute::Custom(cow) => NameAttribute::Custom(Cow::Owned(cow.into_owned())),
+        }
+    }
+}
+
 impl<'a> From<String> for NameAttribute<'a> {
     fn from(s: String) -> Self {
         if let Some(f) = NameAttribute::system(&s) {
@@ -154,5 +166,18 @@ impl<'a> Name<'a> {
     /// names.
     pub fn name(&self) -> &str {
         &*self.name
+    }
+
+    /// Get an owned version of this [`Name`].
+    pub fn into_owned(self) -> Name<'static> {
+        Name {
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(|av| av.into_owned())
+                .collect(),
+            delimiter: self.delimiter.map(|cow| Cow::Owned(cow.into_owned())),
+            name: Cow::Owned(self.name.into_owned()),
+        }
     }
 }

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -92,7 +92,7 @@ pub enum NameAttribute<'a> {
     Custom(Cow<'a, str>),
 }
 
-impl<'a> NameAttribute<'a> {
+impl NameAttribute<'static> {
     fn system(s: &str) -> Option<Self> {
         match s {
             "\\Noinferiors" => Some(NameAttribute::NoInferiors),

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -48,6 +48,16 @@ impl Names {
     pub fn iter(&self) -> Iter<'_, Name<'_>> {
         self.borrow_names().iter()
     }
+
+    /// Get the number of [`Name`]s in this container.
+    pub fn len(&self) -> usize {
+        self.borrow_names().len()
+    }
+
+    /// Return true of there are no [`Name`]s in the container.
+    pub fn is_empty(&self) -> bool {
+        self.borrow_names().is_empty()
+    }
 }
 
 /// A name that matches a `LIST` or `LSUB` command.

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -58,6 +58,11 @@ impl Names {
     pub fn is_empty(&self) -> bool {
         self.borrow_names().is_empty()
     }
+
+    /// Get the element at the given index
+    pub fn get(&self, index: usize) -> Option<&Name<'_>> {
+        self.borrow_names().get(index)
+    }
 }
 
 /// A name that matches a `LIST` or `LSUB` command.

--- a/tests/imap_integration.rs
+++ b/tests/imap_integration.rs
@@ -147,7 +147,7 @@ fn inbox() {
     // let's see that we can also fetch the e-mails
     let fetch = c.fetch("1", "(ALL UID)").unwrap();
     assert_eq!(fetch.len(), 1);
-    let fetch = &fetch[0];
+    let fetch = fetch.iter().next().unwrap();
     assert_eq!(fetch.message, 1);
     assert_ne!(fetch.uid, None);
     assert_eq!(fetch.size, Some(138));
@@ -265,7 +265,7 @@ fn inbox_uid() {
     // let's see that we can also fetch the e-mail
     let fetch = c.uid_fetch(format!("{}", uid), "(ALL UID)").unwrap();
     assert_eq!(fetch.len(), 1);
-    let fetch = &fetch[0];
+    let fetch = fetch.iter().next().unwrap();
     assert_eq!(fetch.uid, Some(uid));
     let e = fetch.envelope().unwrap();
     assert_eq!(e.subject, Some(b"My first e-mail"[..].into()));
@@ -325,7 +325,7 @@ fn append() {
     // fetch the e-mail
     let fetch = c.uid_fetch(format!("{}", uid), "(ALL UID)").unwrap();
     assert_eq!(fetch.len(), 1);
-    let fetch = &fetch[0];
+    let fetch = fetch.iter().next().unwrap();
     assert_eq!(fetch.uid, Some(uid));
     let e = fetch.envelope().unwrap();
     assert_eq!(e.subject, Some(b"My second e-mail"[..].into()));
@@ -376,7 +376,7 @@ fn append_with_flags() {
     // fetch the e-mail
     let fetch = c.uid_fetch(format!("{}", uid), "(ALL UID)").unwrap();
     assert_eq!(fetch.len(), 1);
-    let fetch = &fetch[0];
+    let fetch = fetch.iter().next().unwrap();
     assert_eq!(fetch.uid, Some(uid));
     let e = fetch.envelope().unwrap();
     assert_eq!(e.subject, Some(b"My third e-mail"[..].into()));
@@ -436,7 +436,7 @@ fn append_with_flags_and_date() {
     // fetch the e-mail
     let fetch = c.uid_fetch(format!("{}", uid), "(ALL UID)").unwrap();
     assert_eq!(fetch.len(), 1);
-    let fetch = &fetch[0];
+    let fetch = fetch.iter().next().unwrap();
     assert_eq!(fetch.uid, Some(uid));
     assert_eq!(fetch.internal_date(), Some(date));
 


### PR DESCRIPTION
This converts `Capabilities` to use ouroboros instead of the local `ZeroCopy`.

Because of all the magic that ouroboros `self_referencing` macro adds (`CapabiltiesTryBuilder` and friends) I found it was simpler to move the parsing bit into the `Capabilities` struct itself. I actually prefer this, since it keeps everything related to `Capabilities` in one place, but I understand if you prefer to keep everything related to parsing in `parse.rs`.

Anyway, if this approach for moving from `ZeroCopy` to ouroboros looks like a good approach, then I can do the rest of it similarly here, and `ZeroCopy` can go away, and we can close #125 .

Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/208)
<!-- Reviewable:end -->
