### PR TITLE
Re-export imap-proto

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@ pub use error::{Error, Result};
 
 pub mod extensions;
 
-pub use imap_proto::types as ImapProtoTypes;
+/// imap_proto types
+pub use imap_proto::types as prototypes;
 
 #[cfg(test)]
 mod mock_stream;


### PR DESCRIPTION
Hello,

While trying to parse and put `envelope` data into a database I had problems reaching `imap-proto` types. Re-exporting `imap-proto` fixed this problem, while adding `imap-proto` to my project resulted in type conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/216)
<!-- Reviewable:end -->
