### PR TITLE
doc: reference ::mv, not ::copy, from ::uid_mv

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -995,7 +995,7 @@ impl<T: Read + Write> Session<T> {
         ))
     }
 
-    /// Equivalent to [`Session::copy`], except that all identifiers in `sequence_set` are
+    /// Equivalent to [`Session::mv`], except that all identifiers in `sequence_set` are
     /// [`Uid`]s. See also the [`UID` command](https://tools.ietf.org/html/rfc3501#section-6.4.8)
     /// and the [semantics of `MOVE` and `UID
     /// MOVE`](https://tools.ietf.org/html/rfc6851#section-3.3).


### PR DESCRIPTION
Just a minor doc fix, thanks for this crate :blue_heart:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/226)
<!-- Reviewable:end -->
