### PR TITLE
Add support for APPENDUID response data

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -215,7 +215,7 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
     ///
     /// Note: be sure to set flags and optional date before you
     /// finish the command.
-    pub fn finish(&mut self) -> Result<()> {
+    pub fn finish(&mut self) -> Result<Appended> {
         let flagstr = self
             .flags
             .clone()
@@ -246,7 +246,9 @@ impl<'a, T: Read + Write> AppendCmd<'a, T> {
         self.session.stream.write_all(self.content)?;
         self.session.stream.write_all(b"\r\n")?;
         self.session.stream.flush()?;
-        self.session.read_response().map(|_| ())
+        self.session
+            .read_response()
+            .and_then(|(lines, _)| parse_append(&lines, &mut self.session.unsolicited_responses_tx))
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -754,4 +754,26 @@ mod tests {
             None => panic!("Missing UIDs in APPEND response"),
         };
     }
+
+    #[test]
+    fn parse_multiappend_uid() {
+        // If the user has enabled UIDPLUS (RFC 4315), the response contains an APPENDUID
+        // response code followed by the UIDVALIDITY of the destination mailbox and the
+        // UID assigned to the appended message in the destination mailbox.
+        // If the MULTIAPPEND extension is also used, there can be multiple UIDs.
+        let lines = b"A003 OK [APPENDUID 38505 3955:3957] APPEND completed\r\n";
+        let (mut send, recv) = mpsc::channel();
+        let resp = parse_append(lines, &mut send).unwrap();
+
+        assert!(recv.try_recv().is_err());
+        assert_eq!(resp.uid_validity, Some(38505));
+        match resp.uids {
+            Some(uid_list) => {
+                let mut it = uid_list.iter();
+                assert_eq!(it.next(), Some(&UidSetMember::UidRange(3955..=3957)));
+                assert_eq!(it.next(), None);
+            }
+            None => panic!("Missing UIDs in APPEND response"),
+        };
+    }
 }

--- a/src/types/appended.rs
+++ b/src/types/appended.rs
@@ -1,0 +1,40 @@
+use imap_proto::UidSetMember;
+use std::fmt;
+
+/// Meta-information about a message, as returned by
+/// [`APPEND`](https://tools.ietf.org/html/rfc3501#section-6.3.11).
+/// Note that `APPEND` only returns any data if certain extensions are enabled,
+/// for example [`UIDPLUS`](https://tools.ietf.org/html/rfc4315).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Appended {
+    /// The unique identifier validity value of the mailbox that the message was appended to.
+    /// See [`Uid`] for more details. Only present if server supports [`UIDPLUS`](https://tools.ietf.org/html/rfc4315).
+    pub uid_validity: Option<u32>,
+
+    /// The unique identifier value of the messages that were appended.
+    /// Only present if server supports [`UIDPLUS`](https://tools.ietf.org/html/rfc4315).
+    /// Contains only a single value unless the [`MULTIAPPEND`](https://tools.ietf.org/html/rfc3502) extension
+    /// was used to upload multiple messages.
+    pub uids: Option<Vec<UidSetMember>>,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for Appended {
+    fn default() -> Appended {
+        Appended {
+            uid_validity: None,
+            uids: None,
+        }
+    }
+}
+
+impl fmt::Display for Appended {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "uid_validity: {:?}, uids: {:?}",
+            self.uid_validity, self.uids,
+        )
+    }
+}

--- a/src/types/appended.rs
+++ b/src/types/appended.rs
@@ -1,5 +1,4 @@
 use imap_proto::UidSetMember;
-use std::fmt;
 
 /// Meta-information about a message, as returned by
 /// [`APPEND`](https://tools.ietf.org/html/rfc3501#section-6.3.11).
@@ -26,15 +25,5 @@ impl Default for Appended {
             uid_validity: None,
             uids: None,
         }
-    }
-}
-
-impl fmt::Display for Appended {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "uid_validity: {:?}, uids: {:?}",
-            self.uid_validity, self.uids,
-        )
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -123,3 +123,6 @@ pub use self::deleted::Deleted;
 
 mod unsolicited_response;
 pub use self::unsolicited_response::{AttributeValue, UnsolicitedResponse};
+
+mod appended;
+pub use self::appended::Appended;


### PR DESCRIPTION
If the `UIDPLUS` extension is supported, the server will reply to
`APPEND` commands with the UID of the new message. This can even be a
list of UIDs if the `MULTIAPPEND` extension is also supported.

Make this information available to the user as the result of an
`AppendCmd`. The added doc strings have links to the relevant RFCs.

Related to #131.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/232)
<!-- Reviewable:end -->
