### PR TITLE
Expose MODSEQ attribute in FETCH responses

### DIFF
--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -115,6 +115,17 @@ impl<'a> Fetch<'a> {
         &self.flags[..]
     }
 
+    /// Contains the mod sequence of the performed operation if in response to a `STORE` or
+    /// `UID STORE` with `UNCHANGEDSINCE` in the query arguments.
+    /// `UNCHANGEDSINCE` and the inclusion of the mod sequence in the response are part of the
+    /// [QRESYNC](https://tools.ietf.org/html/rfc7162#section-3.1.3) extension.
+    pub fn mod_seq(&self) -> Option<u64> {
+        self.fetch.iter().find_map(|av| match av {
+            AttributeValue::ModSeq(mod_seq) => Some(*mod_seq),
+            _ => None,
+        })
+    }
+
     /// The bytes that make up the header of this message, if `BODY[HEADER]`, `BODY.PEEK[HEADER]`,
     /// or `RFC822.HEADER` was included in the `query` argument to `FETCH`.
     pub fn header(&self) -> Option<&[u8]> {


### PR DESCRIPTION
If the QRESYNC (RFC 7162) extension is being used, a FETCH response to a
STORE or UID STORE command with the UNCHANGEDSINCE query attribute will
return the mod sequence ID of the performed operation. This information
is crucial for building efficient caching clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/233)
<!-- Reviewable:end -->
