### PR TITLE
Un-export some exposed `parse()` functions

### DIFF
--- a/src/types/acls.rs
+++ b/src/types/acls.rs
@@ -115,7 +115,7 @@ pub struct AclResponse {
 
 impl AclResponse {
     /// Parse the given input into a [`Acl`] response.
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {
@@ -198,7 +198,7 @@ pub struct ListRightsResponse {
 
 impl ListRightsResponse {
     /// Parse the given input into a [`ListRights`] response.
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {
@@ -278,7 +278,7 @@ pub struct MyRightsResponse {
 
 impl MyRightsResponse {
     /// Parse the given input into a [`MyRights`] response.
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {

--- a/src/types/capabilities.rs
+++ b/src/types/capabilities.rs
@@ -45,7 +45,7 @@ pub struct Capabilities {
 
 impl Capabilities {
     /// Parse the given input into one or more [`Capabilitity`] responses.
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -26,7 +26,7 @@ pub struct Fetches {
 
 impl Fetches {
     /// Parse one or more [`Fetch`] responses from a response buffer.
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -18,7 +18,7 @@ pub struct Names {
 
 impl Names {
     /// Parse one or more [`Name`] from a response buffer
-    pub fn parse(
+    pub(crate) fn parse(
         owned: Vec<u8>,
         unsolicited: &mut mpsc::Sender<UnsolicitedResponse>,
     ) -> Result<Self, Error> {


### PR DESCRIPTION
As @jonhoo pointed out [here](https://github.com/jonhoo/rust-imap/pull/249#pullrequestreview-1249037461), the various types' `parse()` functions should not be exported. Some are, though. The 3.0 release is probably a good time to fix that.

Note: some types (e.g. `Mailbox`, `Deleted`) didn't have their `parse()` function exposed, so I think it's pretty safe to assume that nobody built anything seriously using these.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/251)
<!-- Reviewable:end -->
