### PR TITLE
Implementing capability caching

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -138,6 +138,11 @@ fn validate_sequence_set(
 #[derive(Debug)]
 pub struct Session<T: Read + Write> {
     conn: Connection<T>,
+
+    // Capabilities are almost guaranteed to chance if encryption state or authentication state
+    // changes, so caching them in `Connection` is inappropiate.
+    capability_cache: Option<Capabilities>,
+
     pub(crate) unsolicited_responses_tx: mpsc::Sender<UnsolicitedResponse>,
 
     /// Server responses that are not related to the current command. See also the note on
@@ -153,6 +158,10 @@ pub struct Session<T: Read + Write> {
 #[derive(Debug)]
 pub struct Client<T: Read + Write> {
     conn: Connection<T>,
+
+    // Capabilities are almost guaranteed to chance if encryption state or authentication state
+    // changes, so caching them in `Connection` is inappropiate.
+    capability_cache: Option<Capabilities>,
 }
 
 /// The underlying primitives type. Both `Client`(unauthenticated) and `Session`(after succesful
@@ -333,6 +342,7 @@ impl<T: Read + Write> Client<T> {
                 debug: false,
                 greeting_read: false,
             },
+            capability_cache: None,
         }
     }
 
@@ -343,6 +353,47 @@ impl<T: Read + Write> Client<T> {
     pub(crate) fn into_inner(self) -> Result<T> {
         let res = self.conn.stream.into_inner()?;
         Ok(res)
+    }
+
+    /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
+    /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
+    /// one of the listed capabilities. See [`Capabilities`] for further details.
+    ///
+    /// This method will always bypass the local capabilities cache and send a `CAPABILITY` command
+    /// to the server. The [`Self::capabilities()`] method can be used when returning a cached
+    /// response is acceptable.
+    pub fn capabilities_refresh(&mut self) -> Result<&Capabilities> {
+        let (mut tx, _rx) = mpsc::channel();
+        let caps = self.run_command_and_read_response("CAPABILITY")
+            .and_then(|lines| Capabilities::parse(lines, &mut tx))?;
+        self.capability_cache = Some(caps);
+
+        self.capability_cache.as_ref()
+            // This path will not be hit; if the cache is not populated the above calls will either
+            // populate it or return with an early error.
+            .ok_or_else(|| panic!("CAPABILITY call did not populate capability cache!"))
+    }
+
+    /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
+    /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
+    /// one of the listed capabilities. See [`Capabilities`] for further details.
+    ///
+    /// This function will not query the server if a set of capabilities was cached, but request
+    /// and cache capabilities from the server otherwise. The [`Self::capabilities_refresh`] method
+    /// can be used to refresh the cache by forcing a `CAPABILITY` command to be send.
+    pub fn capabilities_ref(&mut self) -> Result<&Capabilities> {
+        let (mut tx, _rx) = mpsc::channel();
+        if self.capability_cache.is_none() {
+            let caps = self.run_command_and_read_response("CAPABILITY")
+                .and_then(|lines| Capabilities::parse(lines, &mut tx))?;
+
+            self.capability_cache = Some(caps);
+        }
+
+        self.capability_cache.as_ref()
+            // This path will not be hit; if the cache is not populated the above `if` will either
+            // populate it or return with an early error.
+            .ok_or_else(|| panic!("CAPABILITY call did not populate capability cache!"))
     }
 
     /// Log in to the IMAP server. Upon success a [`Session`](struct.Session.html) instance is
@@ -502,6 +553,7 @@ impl<T: Read + Write> Session<T> {
         let (tx, rx) = mpsc::channel();
         Session {
             conn,
+            capability_cache: None,
             unsolicited_responses: rx,
             unsolicited_responses_tx: tx,
         }
@@ -774,9 +826,49 @@ impl<T: Read + Write> Session<T> {
     /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
     /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
     /// one of the listed capabilities. See [`Capabilities`] for further details.
+    ///
+    /// This method will always bypass the local capabilities cache and send a `CAPABILITY` command
+    /// to the server. The [`Self::capabilities()`] method can be used when returning a cached
+    /// response is acceptable.
+    pub fn capabilities_refresh(&mut self) -> Result<&Capabilities> {
+        let caps = self.run_command_and_read_response("CAPABILITY")
+            .and_then(|lines| Capabilities::parse(lines, &mut self.unsolicited_responses_tx))?;
+        self.capability_cache = Some(caps);
+
+        self.capability_cache.as_ref()
+            // This path will not be hit; if the cache is not populated the above calls will either
+            // populate it or return with an early error.
+            .ok_or_else(|| panic!("CAPABILITY call did not populate capability cache!"))
+    }
+
+    /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
+    /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
+    /// one of the listed capabilities. See [`Capabilities`] for further details.
+    ///
+    /// This function will not query the server if a set of capabilities was cached, but request
+    /// and cache capabilities from the server otherwise. The [`Self::capabilities_refresh`] method
+    /// can be used to refresh the cache by forcing a `CAPABILITY` command to be send.
+    pub fn capabilities_ref(&mut self) -> Result<&Capabilities> {
+        if self.capability_cache.is_none() {
+            let caps = self.run_command_and_read_response("CAPABILITY")
+                .and_then(|lines| Capabilities::parse(lines, &mut self.unsolicited_responses_tx))?;
+
+            self.capability_cache = Some(caps);
+        }
+
+        self.capability_cache.as_ref()
+            // This path will not be hit; if the cache is not populated the above `if` will either
+            // populate it or return with an early error.
+            .ok_or_else(|| panic!("CAPABILITY call did not populate capability cache!"))
+    }
+
+    /// The [`CAPABILITY` command](https://tools.ietf.org/html/rfc3501#section-6.1.1) requests a
+    /// listing of capabilities that the server supports.  The server will include "IMAP4rev1" as
+    /// one of the listed capabilities. See [`Capabilities`] for further details.
     pub fn capabilities(&mut self) -> Result<Capabilities> {
-        self.run_command_and_read_response("CAPABILITY")
-            .and_then(|lines| Capabilities::parse(lines, &mut self.unsolicited_responses_tx))
+        // TODO: This emulated the same behaviour as before, with each call issuing a command.
+        //       It may be sensible to allow hitting the cache here.
+        self.capabilities_refresh().map(|caps| caps.clone())
     }
 
     /// The [`EXPUNGE` command](https://tools.ietf.org/html/rfc3501#section-6.4.3) permanently

--- a/src/client.rs
+++ b/src/client.rs
@@ -379,7 +379,7 @@ impl<T: Read + Write> Client<T> {
     /// one of the listed capabilities. See [`Capabilities`] for further details.
     ///
     /// This function will not query the server if a set of capabilities was cached, but request
-    /// and cache capabilities from the server otherwise. The [`Self::capabilities_refresh`] method
+    /// and cache capabilities from the server otherwise. The [`Self::current_capabilities`] method
     /// can be used to refresh the cache by forcing a `CAPABILITY` command to be send.
     pub fn capabilities(&mut self) -> Result<&Capabilities> {
         let (mut tx, _rx) = mpsc::channel();
@@ -846,7 +846,7 @@ impl<T: Read + Write> Session<T> {
     /// one of the listed capabilities. See [`Capabilities`] for further details.
     ///
     /// This function will not query the server if a set of capabilities was cached, but request
-    /// and cache capabilities from the server otherwise. The [`Self::capabilities_refresh`] method
+    /// and cache capabilities from the server otherwise. The [`Self::current_capabilities`] method
     /// can be used to refresh the cache by forcing a `CAPABILITY` command to be send.
     pub fn capabilities(&mut self) -> Result<&Capabilities> {
         if self.capability_cache.is_none() {

--- a/src/types/capabilities.rs
+++ b/src/types/capabilities.rs
@@ -48,7 +48,8 @@ impl Clone for Capabilities {
     fn clone(&self) -> Self {
         // Give _rx a name so it's not immediately dropped. Otherwise any unsolicited responses
         // that would be send there will return a SendError instead of the parsed response simply
-        // being dropped later.
+        // being dropped later. Those responses being dropped is safe as they were already parsed
+        // and sent to a consumer when this capabilities response was parsed the first time.
         let (mut tx, _rx) = mpsc::channel();
         Self::parse(self.borrow_data().clone(), &mut tx)
             .expect("failed to parse capabilities from data which was already successfully parse before")


### PR DESCRIPTION
Based on [this comment by @jonhoo on #243](https://github.com/jonhoo/rust-imap/pull/243#discussion_r1008771894) this PR adds the ability for `Client` and `Session` to cache returned `Capabilities`.

Future work should try to parse (the optionally sent) Capabilities from untagged responses to `EHLO`, `STARTTLS`, and `AUTHENTICATE` automatically; if none are sent they should be automatically queried.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/255)
<!-- Reviewable:end -->
