### PR TITLE
Update greenmail docker image version in README.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo test --locked --all-targets
     services:
       greenmail:
-        image: greenmail/standalone:1.6.8
+        image: greenmail/standalone:1.6.15
         ports:
           - 3025:3025
           - 3110:3110

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ running](http://www.icegreen.com/greenmail/#deploy_docker_standalone). The
 easiest way to do that is with Docker:
 
 ```console
-$ docker pull greenmail/standalone:1.6.8
-$ docker run -it --rm -e GREENMAIL_OPTS='-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose' -p 3025:3025 -p 3110:3110 -p 3143:3143 -p 3465:3465 -p 3993:3993 -p 3995:3995 greenmail/standalone:1.6.8
+$ docker pull greenmail/standalone:1.6.15
+$ docker run -it --rm -e GREENMAIL_OPTS='-Dgreenmail.setup.test.all -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.auth.disabled -Dgreenmail.verbose' -p 3025:3025 -p 3110:3110 -p 3143:3143 -p 3465:3465 -p 3993:3993 -p 3995:3995 greenmail/standalone:1.6.15
 ```
 
 Another alternative is to test against cyrus imapd which is a more complete IMAP implementation that greenmail (supporting quotas and ACLs).


### PR DESCRIPTION
Hint to use the newer (stable) `1.6.15` version.
All tests still pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/281)
<!-- Reviewable:end -->
