### PR TITLE
typos: init and run in ci 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,3 +124,10 @@ jobs:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
         run: cargo check
+  spellcheck:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Executes "typos ."
+      - uses: crate-ci/typos@v1.21.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,10 +124,3 @@ jobs:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
         run: cargo check
-  spellcheck:
-    name: Spellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # Executes "typos ."
-      - uses: crate-ci/typos@v1.21.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This directory contains examples of working with the IMAP client.
 
 Examples:
   * basic - This is a very basic example of using the client.
-  * gmail_oauth2 - This is an example using oauth2 for logging into gmail as a secure appplication.
+  * gmail_oauth2 - This is an example using oauth2 for logging into gmail as a secure application.
   * idle - This is an example showing how to use IDLE to monitor a mailbox.
   * rustls - This demonstrates how to use Rustls instead of Openssl for secure connections (helpful for cross compilation).
   * starttls - This is an example showing how to use STARTTLS after connecting over plaintext.

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,7 +98,7 @@ fn validate_str_noquote(
 
 /// This ensures the input doesn't contain a command-terminator or any other whitespace
 /// while leaving it not-quoted.
-/// This is needed because, per [the formal grammer given in RFC
+/// This is needed because, per [the formal grammar given in RFC
 /// 3501](https://tools.ietf.org/html/rfc3501#section-9), a sequence set consists of the following:
 ///
 /// > sequence-set = (seq-number / seq-range) *("," sequence-set)
@@ -130,7 +130,7 @@ fn validate_sequence_set(
 }
 
 /// An authenticated IMAP session providing the usual IMAP commands. This type is what you get from
-/// a succesful login attempt.
+/// a successful login attempt.
 ///
 /// Note that the server *is* allowed to unilaterally send things to the client for messages in
 /// a selected mailbox whose status has changed. See the note on [unilateral server responses
@@ -149,7 +149,7 @@ pub struct Session<T: Read + Write> {
 }
 
 /// An (unauthenticated) handle to talk to an IMAP server. This is what you get when first
-/// connecting. A succesfull call to [`Client::login`] or [`Client::authenticate`] will return a
+/// connecting. A successful call to [`Client::login`] or [`Client::authenticate`] will return a
 /// [`Session`] instance that provides the usual IMAP methods.
 // Both `Client` and `Session` deref to [`Connection`](struct.Connection.html), the underlying
 // primitives type.
@@ -158,7 +158,7 @@ pub struct Client<T: Read + Write> {
     conn: Connection<T>,
 }
 
-/// The underlying primitives type. Both `Client`(unauthenticated) and `Session`(after succesful
+/// The underlying primitives type. Both `Client`(unauthenticated) and `Session`(after successful
 /// login) use a `Connection` internally for the TCP stream primitives.
 #[derive(Debug)]
 #[doc(hidden)]
@@ -297,7 +297,7 @@ impl<T: Read + Write> DerefMut for Session<T> {
 }
 
 // As the pattern of returning the unauthenticated `Client` (a.k.a. `self`) back with a login error
-// is relatively common, it's abstacted away into a macro here.
+// is relatively common, it's abstracted away into a macro here.
 //
 // Note: 1) using `.map_err(|e| (e, self))` or similar here makes the closure own self, so we can't
 //          do that.
@@ -379,7 +379,7 @@ impl<T: Read + Write> Client<T> {
     /// Log in to the IMAP server. Upon success a [`Session`](struct.Session.html) instance is
     /// returned; on error the original `Client` instance is returned in addition to the error.
     /// This is because `login` takes ownership of `self`, so in order to try again (e.g. after
-    /// prompting the user for credetials), ownership of the original `Client` needs to be
+    /// prompting the user for credentials), ownership of the original `Client` needs to be
     /// transferred back to the caller.
     ///
     /// ```rust,no_run
@@ -479,7 +479,7 @@ impl<T: Read + Write> Client<T> {
         loop {
             let mut line = Vec::new();
 
-            // explicit match blocks neccessary to convert error to tuple and not bind self too
+            // explicit match blocks necessary to convert error to tuple and not bind self too
             // early (see also comment on `login`)
             ok_or_unauth_client_err!(self.readline(&mut line), self);
 
@@ -827,7 +827,7 @@ impl<T: Read + Write> Session<T> {
     ///
     /// This command is particularly useful for disconnected use clients. By using `uid_expunge`
     /// instead of [`expunge`](Session::expunge) when resynchronizing with the server, the client
-    /// can ensure that it does not inadvertantly remove any messages that have been marked as
+    /// can ensure that it does not inadvertently remove any messages that have been marked as
     /// [`Flag::Deleted`] by other clients between the time that the client was last connected and
     /// the time the client resynchronizes.
     ///
@@ -1363,7 +1363,7 @@ impl<T: Read + Write> Session<T> {
 
     /// The [`GETACL` command](https://datatracker.ietf.org/doc/html/rfc4314#section-3.3)
     ///
-    /// Returns the ACLs on the given mailbox. A set ot `ACL` responses are returned if the
+    /// Returns the ACLs on the given mailbox. A set of `ACL` responses are returned if the
     /// logged in user has `a` rights on the mailbox.  Otherwise, will return [`Error::No`].
     ///
     /// This method only works against a server with the ACL capability. Otherwise [`Error::Bad`]
@@ -1379,7 +1379,7 @@ impl<T: Read + Write> Session<T> {
     /// The [`LISTRIGHTS` command](https://datatracker.ietf.org/doc/html/rfc4314#section-3.4)
     ///
     /// Returns the always granted and optionally granted rights on the given mailbox for the
-    /// specified identifier (login). A set ot `LISTRIGHTS` responses are returned if the
+    /// specified identifier (login). A set of `LISTRIGHTS` responses are returned if the
     /// logged in user has `a` rights on the mailbox.  Otherwise, will return [`Error::No`].
     ///
     /// This method only works against a server with the ACL capability. Otherwise [`Error::Bad`]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Bad {
-    /// Human-redable message included with the Bad response.
+    /// Human-readable message included with the Bad response.
     pub information: String,
     /// A more specific error status code included with the Bad response.
     pub code: Option<ResponseCode<'static>>,
@@ -41,7 +41,7 @@ impl fmt::Display for Bad {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct No {
-    /// Human-redable message included with the NO response.
+    /// Human-readable message included with the NO response.
     pub information: String,
     /// A more specific error status code included with the NO response.
     pub code: Option<ResponseCode<'static>>,
@@ -57,7 +57,7 @@ impl fmt::Display for No {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Bye {
-    /// Human-redable message included with the response.
+    /// Human-readable message included with the response.
     pub information: String,
     /// A more specific error status code included with the response.
     pub code: Option<ResponseCode<'static>>,
@@ -232,7 +232,7 @@ impl StdError for Error {
     }
 }
 
-/// An error occured while trying to parse a server response.
+/// An error occurred while trying to parse a server response.
 #[derive(Debug)]
 pub enum ParseError {
     /// Indicates an error parsing the status response. Such as OK, NO, and BAD.

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -1,4 +1,4 @@
-//! Adds support for the IMAP IDLE command specificed in [RFC
+//! Adds support for the IMAP IDLE command specified in [RFC
 //! 2177](https://tools.ietf.org/html/rfc2177).
 
 use crate::client::Session;
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// `Handle` allows a client to block waiting for changes to the remote mailbox.
 ///
 /// The handle blocks using the [`IDLE` command](https://tools.ietf.org/html/rfc2177#section-3)
-/// specificed in [RFC 2177](https://tools.ietf.org/html/rfc2177) until the underlying server state
+/// specified in [RFC 2177](https://tools.ietf.org/html/rfc2177) until the underlying server state
 /// changes in some way.
 ///
 /// The `wait_while` function takes a callback function which receives any responses

--- a/src/extensions/list_status.rs
+++ b/src/extensions/list_status.rs
@@ -1,4 +1,4 @@
-//! Adds support for the IMAP LIST-STATUS extension specificed in [RFC
+//! Adds support for the IMAP LIST-STATUS extension specified in [RFC
 //! 5819](https://tools.ietf.org/html/rfc5819).
 
 use crate::client::{validate_str, Session};

--- a/src/extensions/metadata.rs
+++ b/src/extensions/metadata.rs
@@ -1,4 +1,4 @@
-//! Adds support for the IMAP METADATA extension specificed in [RFC
+//! Adds support for the IMAP METADATA extension specified in [RFC
 //! 5464](https://tools.ietf.org/html/rfc5464).
 //!
 //! Mailboxes or the server as a whole may have zero or more annotations associated with them. An

--- a/src/extensions/sort.rs
+++ b/src/extensions/sort.rs
@@ -1,4 +1,4 @@
-//! Adds support for the IMAP SORT extension specificed in [RFC
+//! Adds support for the IMAP SORT extension specified in [RFC
 //! 5464](https://tools.ietf.org/html/rfc5256#section-3).
 //!
 //! The SORT command is a variant of SEARCH with sorting semantics for

--- a/src/types/deleted.rs
+++ b/src/types/deleted.rs
@@ -15,7 +15,7 @@ use std::ops::RangeInclusive;
 /// knows that they should be receiving an `EXPUNGE` or `VANISHED` response,
 /// then they can use [`seqs()`](#method.seqs) to get an iterator over `EXPUNGE`
 /// message sequence numbers, or [`uids()`](#method.uids) to get an iterator over
-/// the `VANISHED` UIDs. As a convenience `Deleted` also implents `IntoIterator`
+/// the `VANISHED` UIDs. As a convenience `Deleted` also implements `IntoIterator`
 /// which just returns an iterator over whatever is contained within.
 ///
 /// # Examples

--- a/src/types/unsolicited_response.rs
+++ b/src/types/unsolicited_response.rs
@@ -153,9 +153,9 @@ pub enum UnsolicitedResponse {
 ///
 /// Not all `Response` variants are supported - only those which
 /// are known or likely to be sent by a server as a unilateral response
-/// during normal operations or during an IDLE session are implented.
+/// during normal operations or during an IDLE session are implemented.
 ///
-/// If the conversion fails, the input `Reponse` is returned.
+/// If the conversion fails, the input `Response` is returned.
 impl<'a> TryFrom<Response<'a>> for UnsolicitedResponse {
     type Error = Response<'a>;
 


### PR DESCRIPTION
Fix various [typos](https://github.com/crate-ci/typos) and run typos in CI-.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/289)
<!-- Reviewable:end -->
