### PR TITLE
Allow padded authentication tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "imap"
-version = "3.0.0-alpha.14"
+version = "3.0.0-alpha.15"
 dependencies = [
  "base64 0.22.0",
  "bufstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imap"
-version = "3.0.0-alpha.14"
+version = "3.0.0-alpha.15"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>",
            "Matt McCoy <mattnenterprise@yahoo.com>"]
 documentation = "https://docs.rs/imap/"

--- a/src/client.rs
+++ b/src/client.rs
@@ -501,7 +501,7 @@ impl<T: Read + Write> Client<T> {
                     let data =
                         ok_or_unauth_client_err!(parse_authenticate_response(line_str), self);
                     ok_or_unauth_client_err!(
-                        general_purpose::STANDARD_NO_PAD
+                        general_purpose::STANDARD
                             .decode(data)
                             .map_err(|e| Error::Parse(ParseError::Authentication(
                                 data.to_string(),
@@ -512,7 +512,7 @@ impl<T: Read + Write> Client<T> {
                 };
 
                 let raw_response = &authenticator.process(&challenge);
-                let auth_response = general_purpose::STANDARD_NO_PAD.encode(raw_response);
+                let auth_response = general_purpose::STANDARD.encode(raw_response);
                 ok_or_unauth_client_err!(
                     self.write_line(auth_response.into_bytes().as_slice()),
                     self


### PR DESCRIPTION
I honestly couldn't tell you why `NO_PAD` was chosen. It seems to have happened somewhat arbitrarily when the `base64` major upgrade that introduced the distinction landed in #253.

Time to fix that.

Fixes #299.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-imap/305)
<!-- Reviewable:end -->
