### PR TITLE
Added SPECIAL-USE to list_status

### DIFF
--- a/src/extensions/list_status.rs
+++ b/src/extensions/list_status.rs
@@ -145,10 +145,12 @@ impl<T: Read + Write> Session<T> {
         data_items: &str,
     ) -> Result<ExtendedNames> {
         let reference = validate_str("LIST-STATUS", "reference", reference_name.unwrap_or(""))?;
+        let capabilities = self.capabilities();
         let lines = self.run_command_and_read_response(format!(
-            "LIST {} {} RETURN (STATUS {})",
+            "LIST {} {} RETURN ({}STATUS {})",
             &reference,
             mailbox_pattern.unwrap_or("\"\""),
+            if capabilities.is_ok_and(|c| c.has_str("SPECIAL-USE")) { "SPECIAL-USE " } else { "" },
             data_items
         ))?;
         ExtendedNames::parse(lines, &mut self.unsolicited_responses)


### PR DESCRIPTION
Some servers don't return SPECIAL-USE attributes unless they are explicitly requested in the LIST-EXTENDED command. This change makes the `list_status()` method a little bit more useful if SPECIAL-USE is included in the list of capabilities.

I know that this issues a CAPABILITY command before every LIST but it seems better than having to issue a STATUS for every folder just to get the SPECIAL-USE attributes. Given that capabilities usually don't change after login it would probably make sense to cache them at session level (I can provide a patch in that sense if you like).